### PR TITLE
Fix minor typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Brought to you by Offensive CounterMeasures
 
 RITA is not production ready! This software is being released open source as it
 is being worked on. The team at OCM (Offensive CounterMeasures) has been
-diligently working on the process of seperating the analysis logic from the
+diligently working on the process of separating the analysis logic from the
 front end which is destined to be product for sale by Offensive CounterMeasures.
 
 ###Current state

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -40,14 +40,14 @@ Bro:
     # All databases in this test will get prefixed with the database prefix
     DBPrefix: PrefixForDatabase
 
-    # Subdirectories of LogPath may be seperated into different databases for the
+    # Subdirectories of LogPath may be separated into different databases for the
     # test. Map each directory to the database you wish that directory to wind up
     # in. This is good for running tests against multiple subnets and network
     # segments. Put the directory name on the left side of the colon, and the
     # database you wish the logs from that directory to go in on the right side.
     DirectoryMap:
-        UniqueDir: SeperateDatabaseName
-        UniqueDir2: SeperateDatabaseName2
+        UniqueDir: SeparateDatabaseName
+        UniqueDir2: SeparateDatabaseName2
 
     # If set, files which don't match the directory map will be placed
     # in this default database.
@@ -55,8 +55,8 @@ Bro:
 
     # There needs to be one metadatabase per test. This database holds information
     # about the test and the files related to the test. If there are several
-    # subnets mapped in DirectoryMap each will be handled seperately and that
-    # seperation is handled by the metadatabase.
+    # subnets mapped in DirectoryMap each will be handled separately and that
+    # separation is handled by the metadatabase.
     MetaDB: MetaDataBase
 
     # If the ingestor is running slowly and there is plenty of resources
@@ -68,7 +68,7 @@ Bro:
 
     # If use dates is true the logs will be split into databases by date, this is
     # best for if you have multiple days worth of log files in the logpath and wish
-    # to treat each day as a seperate test. 24hours worth of data is the ideal for
+    # to treat each day as a separate test. 24hours worth of data is the ideal for
     # analysis, and using dates will ensure that tests are broken into 24hour periods
     # around midnight of each day.
     UseDates: true


### PR DESCRIPTION
I noticed a typo of "seperate" in the yaml so I grepped through the repo for that typo and fixed it.