### PR TITLE
Fix insecure mongod startup recommendation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ data.
   1. Otherwise if you're a very busy person like us, you can fork the process as a daemon. Make the log file and grant appropriate permissions
     * ```sudo touch /data/mongod.log && sudo chown <username> mongod.log && sudo chmod u+w /data/mongod.log```
   1. Then start mongod daemon with
-    * ```mongod --fork --logpath /data/mongod.log```
+    * ```mongod --fork --logpath /data/mongod.log -f /etc/mongod.conf```
   1. If mongo is still not running, you can check out further documentation at https://docs.mongodb.com/
 
 1. Configuring the system


### PR DESCRIPTION
# Problem

The way the instructions are currently written, if you follow 5.vi, `mongod` will bind to all interfaces because a config file is not specified to apply the appropriate [net.bindIp](https://docs.mongodb.com/manual/reference/configuration-options/#net.bindIp) setting.

# Solution

Option 1 (In PR):  Append ` -f /etc/mongod.conf` to `mongod --fork --logpath /data/mongod.log` in 5.vi

Option 2:  Replace steps 5.v and 5.vi with `systemctl start mongod` or `service mongod start`, which will also change the location of the log to `/var/log/mongodb/mongod.log` by default.  It also appears (at least for me) that this will change the location of your mongodb db files.