### PR TITLE
Make sure beaconing runs on a single core

### DIFF
--- a/analysis/TBD/TBD.go
+++ b/analysis/TBD/TBD.go
@@ -69,9 +69,9 @@ func New(c *config.Resources) *TBD {
 		collectChannel:    make(chan string),
 		analysisChannel:   make(chan *tbdAnalysisInput),
 		writeChannel:      make(chan *datatype_TBD.TBDAnalysisOutput),
-		collectThreads:    runtime.NumCPU() / 2,
-		analysisThreads:   runtime.NumCPU() / 2,
-		writeThreads:      runtime.NumCPU() / 2,
+		collectThreads:    util.Max(1, runtime.NumCPU()/2),
+		analysisThreads:   util.Max(1, runtime.NumCPU()/2),
+		writeThreads:      util.Max(1, runtime.NumCPU()/2),
 	}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -348,3 +348,18 @@ func Abs(a int64) int64 {
 func Round(f float64) int64 {
 	return int64(math.Floor(f + .5))
 }
+
+//retun the smaller of two integers
+func Min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func Max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
p.s. go doesn't have a min/max for ints in the standard library