### PR TITLE
Added cross reference analysis for scanning and beaconing. Additionally fixed aggregations.

### DIFF
--- a/analysis/TBD/TBD.go
+++ b/analysis/TBD/TBD.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/ocmdev/rita/database"
@@ -61,11 +62,9 @@ func BuildTBDCollection(res *database.Resources) {
 	newTBD(res).run()
 }
 
-func GetTBDResultsView(res *database.Resources, cutoffScore float64) []dataTBD.TBDAnalysisView {
+func GetTBDResultsView(res *database.Resources, cutoffScore float64) *mgo.Iter {
 	pipeline := getViewPipeline(res, cutoffScore)
-	var results []dataTBD.TBDAnalysisView
-	res.DB.AggregateCollection(res.System.TBDConfig.TBDTable, pipeline, &results)
-	return results
+	return res.DB.AggregateCollection(res.System.TBDConfig.TBDTable, pipeline)
 }
 
 // New creates a new TBD module

--- a/analysis/TBD/TBD.go
+++ b/analysis/TBD/TBD.go
@@ -378,6 +378,8 @@ func getViewPipeline(r *database.Resources, cuttoff float64) []bson.D {
 				{"ts_score", 1},
 				{"src", "$uconn.src"},
 				{"dst", "$uconn.dst"},
+				{"local_src", "$uconn.local_src"},
+				{"local_dst", "$uconn.local_dst"},
 				{"connection_count", "$uconn.connection_count"},
 				{"avg_bytes", "$uconn.avg_bytes"},
 				{"ts_iRange", 1},

--- a/analysis/crossref/beaconing.go
+++ b/analysis/crossref/beaconing.go
@@ -1,0 +1,21 @@
+package crossref
+
+import "github.com/ocmdev/rita/database"
+
+type (
+	BeaconingSelector struct{}
+)
+
+func (s BeaconingSelector) GetName() string {
+	return "beaconing"
+}
+
+func (s BeaconingSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
+	internalHosts := make(chan string)
+	externalHosts := make(chan string)
+	go func() {
+		close(internalHosts)
+		close(externalHosts)
+	}()
+	return internalHosts, externalHosts
+}

--- a/analysis/crossref/beaconing.go
+++ b/analysis/crossref/beaconing.go
@@ -1,6 +1,10 @@
 package crossref
 
-import "github.com/ocmdev/rita/database"
+import (
+	"github.com/ocmdev/rita/analysis/TBD"
+	"github.com/ocmdev/rita/database"
+	dataTBD "github.com/ocmdev/rita/datatypes/TBD"
+)
 
 type (
 	BeaconingSelector struct{}
@@ -11,9 +15,26 @@ func (s BeaconingSelector) GetName() string {
 }
 
 func (s BeaconingSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
+	// make channels to return
 	internalHosts := make(chan string)
 	externalHosts := make(chan string)
+	// run the read code async and return the channels immediately
 	go func() {
+		iter := TBD.GetTBDResultsView(res, .7)
+
+		var data dataTBD.TBDAnalysisView
+		for iter.Next(&data) {
+			if data.LocalSrc {
+				internalHosts <- data.Src
+			} else {
+				externalHosts <- data.Src
+			}
+			if data.LocalDst {
+				internalHosts <- data.Dst
+			} else {
+				externalHosts <- data.Dst
+			}
+		}
 		close(internalHosts)
 		close(externalHosts)
 	}()

--- a/analysis/crossref/beaconing.go
+++ b/analysis/crossref/beaconing.go
@@ -20,7 +20,7 @@ func (s BeaconingSelector) Select(res *database.Resources) (<-chan string, <-cha
 	externalHosts := make(chan string)
 	// run the read code async and return the channels immediately
 	go func() {
-		iter := TBD.GetTBDResultsView(res, .7)
+		iter := TBD.GetTBDResultsView(res, res.System.CrossrefConfig.TBDThreshold)
 
 		var data dataTBD.TBDAnalysisView
 		for iter.Next(&data) {

--- a/analysis/crossref/crossref.go
+++ b/analysis/crossref/crossref.go
@@ -1,0 +1,67 @@
+package crossref
+
+import (
+	"sync"
+
+	"github.com/ocmdev/rita/database"
+)
+
+type (
+	XRefSelector interface {
+		GetName() string                                           // the name of the analyis module
+		Select(*database.Resources) (<-chan string, <-chan string) // returns the (internal, external) hosts
+	}
+)
+
+func getXRefSelectors() []XRefSelector {
+	beaconing := BeaconingSelector{}
+	scanning := ScanningSelector{}
+
+	return []XRefSelector{beaconing, scanning}
+}
+
+func BuildCrossrefCollection(res *database.Resources) {
+	//maps from analysis types to channels of hosts found
+	internal := make(map[string]<-chan string)
+	external := make(map[string]<-chan string)
+
+	//kick off reads
+	for _, selector := range getXRefSelectors() {
+		internalHosts, externalHosts := selector.Select(res)
+		internal[selector.GetName()] = internalHosts
+		external[selector.GetName()] = externalHosts
+	}
+
+	//build internal and external at the same time
+	multiplexCrossref(res, "internXREF", internal)
+	multiplexCrossref(res, "externXREF", external)
+}
+
+func multiplexCrossref(res *database.Resources, collection string,
+	internalHosts map[string]<-chan string) {
+
+	//each analysis type, while Mongo has awesome document level concurrency
+	//writing the results from two different tests will lead to lock contention
+	//however, we can spin up several threads per test type
+	for name, hosts := range internalHosts {
+		internWG := new(sync.WaitGroup)
+
+		//create a number of threads to write
+		//TODO config this value
+		for i := 0; i < 2; i++ {
+			internWG.Add(1)
+			go writeCrossref(res, collection, name, hosts, internWG)
+		}
+		internWG.Wait()
+	}
+}
+
+func writeCrossref(res *database.Resources, collection string, name string,
+	hosts <-chan string, externWG *sync.WaitGroup) {
+
+	for host := range hosts {
+		//mongo upsert
+		_ = host
+	}
+	externWG.Done()
+}

--- a/analysis/crossref/scanning.go
+++ b/analysis/crossref/scanning.go
@@ -1,0 +1,41 @@
+package crossref
+
+import (
+	"github.com/ocmdev/rita/database"
+	"github.com/ocmdev/rita/datatypes/scanning"
+)
+
+type (
+	ScanningSelector struct{}
+)
+
+func (s ScanningSelector) GetName() string {
+	return "scanning"
+}
+
+func (s ScanningSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
+	internalHosts := make(chan string)
+	externalHosts := make(chan string)
+	go func() {
+		ssn := res.DB.Session.Copy()
+		iter := ssn.DB(res.DB.GetSelectedDB()).
+			C(res.System.ScanningConfig.ScanTable).Find(nil).Iter()
+
+		var data scanning.Scan
+		for iter.Next(&data) {
+			if data.LocalSrc {
+				internalHosts <- data.Src
+			} else {
+				externalHosts <- data.Src
+			}
+			if data.LocalDst {
+				internalHosts <- data.Dst
+			} else {
+				externalHosts <- data.Dst
+			}
+		}
+		close(internalHosts)
+		close(externalHosts)
+	}()
+	return internalHosts, externalHosts
+}

--- a/analysis/crossref/scanning.go
+++ b/analysis/crossref/scanning.go
@@ -20,6 +20,7 @@ func (s ScanningSelector) Select(res *database.Resources) (<-chan string, <-chan
 	// run the read code async and return the channels immediately
 	go func() {
 		ssn := res.DB.Session.Copy()
+		defer ssn.Close()
 		iter := ssn.DB(res.DB.GetSelectedDB()).
 			C(res.System.ScanningConfig.ScanTable).Find(nil).Iter()
 

--- a/analysis/crossref/scanning.go
+++ b/analysis/crossref/scanning.go
@@ -14,8 +14,10 @@ func (s ScanningSelector) GetName() string {
 }
 
 func (s ScanningSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
+	// make channels to return
 	internalHosts := make(chan string)
 	externalHosts := make(chan string)
+	// run the read code async and return the channels immediately
 	go func() {
 		ssn := res.DB.Session.Copy()
 		iter := ssn.DB(res.DB.GetSelectedDB()).

--- a/analysis/scanning/scan.go
+++ b/analysis/scanning/scan.go
@@ -22,8 +22,7 @@ func BuildScanningCollection(res *database.Resources) {
 	}
 
 	// Aggregate it!
-	results := []bson.M{}
-	res.DB.AggregateCollection(source_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(source_collection_name, pipeline)
 }
 
 func getScanningCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -28,9 +28,7 @@ func BuildHostsCollection(res *database.Resources) {
 		return
 	}
 
-	// In case we need results
-	results := []bson.M{}
-	res.DB.AggregateCollection(source_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(source_collection_name, pipeline)
 }
 
 func getHosts(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/structure/uconn.go
+++ b/analysis/structure/uconn.go
@@ -22,8 +22,7 @@ func BuildUniqueConnectionsCollection(res *database.Resources) {
 	}
 
 	// In case we need results
-	results := []bson.M{}
-	res.DB.AggregateCollection(source_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(source_collection_name, pipeline)
 }
 
 func getUniqueConnectionsScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/urls/url.go
+++ b/analysis/urls/url.go
@@ -29,8 +29,7 @@ func BuildUrlsCollection(res *database.Resources) {
 	}
 
 	// Aggregate it
-	results := []bson.M{}
-	res.DB.AggregateCollection(new_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(new_collection_name, pipeline)
 }
 
 func getUrlCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, mgo.MapReduce, []bson.D) {
@@ -89,8 +88,7 @@ func BuildHostnamesCollection(res *database.Resources) {
 		return
 	}
 
-	results := []bson.M{}
-	res.DB.AggregateCollection(source_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(source_collection_name, pipeline)
 }
 
 func getHostnamesAggregationScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/useragent/useragent.go
+++ b/analysis/useragent/useragent.go
@@ -22,8 +22,7 @@ func BuildUserAgentCollection(res *database.Resources) {
 	}
 
 	// Aggregate it!
-	results := []bson.M{}
-	res.DB.AggregateCollection(source_collection_name, pipeline, &results)
+	res.DB.AggregateCollection(source_collection_name, pipeline)
 }
 
 func getUserAgentCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -42,7 +42,8 @@ func showBeacons(c *cli.Context) error {
 	res := database.InitResources("")
 	res.DB.SelectDB(c.String("database"))
 
-	data := TBD.GetTBDResultsView(res, cutoffScore)
+	var data []tbdData.TBDAnalysisView
+	TBD.GetTBDResultsView(res, cutoffScore).All(data)
 
 	if humanreadable {
 		return showBeaconReport(data)

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type (
 		Whitelist         []string        `yaml:"WhiteList"`
 		ImportWhitelist   bool            `yaml:"ImportWhitelist"`
 		BlacklistedConfig BlacklistedCfg  `yaml:"BlackListed"`
+		CrossrefConfig    CrossrefCfg     `yaml:"Crossref"`
 		ScanningConfig    ScanningCfg     `yaml:"Scanning"`
 		StructureConfig   StructureCfg    `yaml:"Structure"`
 		TBDConfig         TBDCfg          `yaml:"TBD"`
@@ -43,6 +44,12 @@ type (
 		ChannelSize       int    `yaml:"ChannelSize"`
 		BlacklistTable    string `yaml:"BlackListTable"`
 		BlacklistDatabase string `yaml:"Database"`
+	}
+
+	CrossrefCfg struct {
+		InternalTable string  `yaml:"InternalTable"`
+		ExternalTable string  `yaml:"ExternalTable"`
+		TBDThreshold  float64 `yaml:"TBDThreshold"`
 	}
 
 	SafeBrowsingCfg struct {

--- a/datatypes/TBD/TBD.go
+++ b/datatypes/TBD/TBD.go
@@ -25,6 +25,8 @@ type (
 		ID             bson.ObjectId `bson:"_id,omitempty"`
 		Src            string        `bson:"src"`
 		Dst            string        `bson:"dst"`
+		LocalSrc       bool          `bson:"local_src"`
+		LocalDst       bool          `bson:"local_dst"`
 		Connections    int64         `bson:"connection_count"`
 		AvgBytes       float64       `bson:"avg_bytes"`
 		TS_iRange      int64         `bson:"ts_iRange"`

--- a/datatypes/crossref/crossref.go
+++ b/datatypes/crossref/crossref.go
@@ -1,0 +1,22 @@
+package crossref
+
+import (
+	"github.com/ocmdev/rita/database"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type (
+	XRef struct {
+		ID         bson.ObjectId `bson:"_id,omitempty"`
+		ModuleName string        `bson:"module"`
+		Host       string        `bson:"host"`
+	}
+
+	//XRefSelector selects internal and external hosts from analysis modules
+	XRefSelector interface {
+		// GetName returns the name of the analyis module
+		GetName() string
+		// Select returns channels containgin the internal and external hosts
+		Select(*database.Resources) (<-chan string, <-chan string)
+	}
+)

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -91,6 +91,11 @@ BlackListed:
     BlackListTable: blacklisted
     Database: rita-blacklist
 
+Crossref:
+    InternalTable: internXREF
+    ExternalTable: externXREF
+    TBDThreshold: .7
+
 Scanning:
     ScanThreshold: 50
     ScanTable: scan


### PR DESCRIPTION
Aggregations were using .all to pull the results back into the client every time we aggregated. I changed the method to return an iterator. Additionally, I added cross reference analysis to the analysis modules. It is designed with an expansible selector framework. Scanning and beaconing selectors have been created.

WARNING!!!!! Unfortunately, this code is poorly tested. It compiles and looks correct, but I am not in a position to test the code.

This pull request serves to inform developers of code to come. The crossref analysis will be represented by two collections: internXREF and externXREF. The schema for records in these collections is string: name, string: host where name is the name of the analysis module in which this host was found.
Mongo does not enforce unique restraints on it's indexes so for hosts found in multiple modules, multiple documents are created.