### PR TITLE
Bugfixes for staging branch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,12 +54,12 @@ To obtain an API key:
   * If the API Manager page isn't already open, open the left side menu and select **API Manager**.
   * On the left, choose **Credentials**.
   * Click **Create credentials** and then select **API key**.
-  * On the left, choose **Library**
-  * Search for **Safe Browsing**
-  * Click on **Google Safe Browsing API**
-  * Near the top, click **Enable**
-  
-Copy this API key to the **APIKey** field under **SafeBrowsing** in the configuration file.
+  * Copy this API key to the **APIKey** field under **SafeBrowsing** in the configuration file.
+  * On the left, choose **Library**.
+  * Search for **Safe Browsing**.
+  * Click on **Google Safe Browsing API**.
+  * Near the top, click **Enable**.
+
 
 ### Getting Started
 **Note: WORKING ON THIS SECTION**

--- a/Readme.md
+++ b/Readme.md
@@ -54,13 +54,17 @@ To obtain an API key:
   * If the API Manager page isn't already open, open the left side menu and select **API Manager**.
   * On the left, choose **Credentials**.
   * Click **Create credentials** and then select **API key**.
+  * On the left, choose **Library**
+  * Search for **Safe Browsing**
+  * Click on **Google Safe Browsing API**
+  * Near the top, click **Enable**
   
 Copy this API key to the **APIKey** field under **SafeBrowsing** in the configuration file.
 
-### Getting Started 
+### Getting Started
 **Note: WORKING ON THIS SECTION**
  * Will describe collecting logs, importing, and analyzing.
- * Also planning on writing an entry in the wiki on setting up a tap/span port and collecting bro logs. 
+ * Also planning on writing an entry in the wiki on setting up a tap/span port and collecting bro logs.
 
 ###Getting help
 Head over to OFTC and join #ocmdev for any questions you may have. Please

--- a/analysis/TBD/TBD.go
+++ b/analysis/TBD/TBD.go
@@ -62,9 +62,9 @@ func BuildTBDCollection(res *database.Resources) {
 	newTBD(res).run()
 }
 
-func GetTBDResultsView(res *database.Resources, cutoffScore float64) *mgo.Iter {
+func GetTBDResultsView(res *database.Resources, ssn *mgo.Session, cutoffScore float64) *mgo.Iter {
 	pipeline := getViewPipeline(res, cutoffScore)
-	return res.DB.AggregateCollection(res.System.TBDConfig.TBDTable, pipeline)
+	return res.DB.AggregateCollection(res.System.TBDConfig.TBDTable, ssn, pipeline)
 }
 
 // New creates a new TBD module

--- a/analysis/blacklisted/blacklisted.go
+++ b/analysis/blacklisted/blacklisted.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ocmdev/rita/analysis/structure"
+	"github.com/ocmdev/rita/analysis/urls"
 	"github.com/ocmdev/rita/database"
 
 	"github.com/google/safebrowsing"
@@ -45,6 +47,16 @@ type (
 		Url string `bson:"host"`
 	}
 )
+
+func SetBlacklistSources(res *database.Resources, result *blacklisted.Blacklist) {
+	if result.IsUrl {
+		for _, destIP := range urls.GetIPsFromHost(res, result.Host) {
+			result.Sources = append(result.Sources, structure.GetConnSourcesFromDest(res, destIP)...)
+		}
+	} else {
+		result.Sources = structure.GetConnSourcesFromDest(res, result.Host)
+	}
+}
 
 func BuildBlacklistedCollection(res *database.Resources) {
 	collection_name := res.System.BlacklistedConfig.BlacklistTable

--- a/analysis/blacklisted/blacklisted.go
+++ b/analysis/blacklisted/blacklisted.go
@@ -42,8 +42,7 @@ type (
 	// UrlShort is a shortened version of the URL datatype that only accounts
 	// for the IP and url (hostname)
 	UrlShort struct {
-		Url string   `bson:"host"`
-		IPs []string `bson:"ips"`
+		Url string `bson:"host"`
 	}
 )
 
@@ -157,12 +156,6 @@ func (b *Blacklisted) run() {
 
 		var u UrlShort
 		for iter.Next(&u) {
-			for _, ip := range u.IPs {
-				if util.RFC1918(ip) {
-					continue
-				}
-				ipchan <- ip
-			}
 			urlchan <- u
 		}
 	}(urlit, urls, ipaddrs)
@@ -190,7 +183,6 @@ func (b *Blacklisted) processIPs(ip chan string, waitgroup *sync.WaitGroup) {
 		if !ok {
 			return
 		}
-
 		// Append the sources that determined this host
 		// was blacklisted
 		sourcelist := []string{}
@@ -202,7 +194,6 @@ func (b *Blacklisted) processIPs(ip chan string, waitgroup *sync.WaitGroup) {
 				score += 1
 				sourcelist = append(sourcelist, val.HostList)
 			}
-
 		}
 
 		if score > 0 {
@@ -252,11 +243,8 @@ func (b *Blacklisted) processURLs(urls chan UrlShort, waitgroup *sync.WaitGroup,
 		if b.safeBrowser != nil {
 			result, _ := b.safeBrowser.LookupURLs(urlList)
 			if len(result) > 0 && len(result[0]) > 0 {
-				for _ = range url.IPs {
-					score += 1
-					// TODO: Populate this with the information returned from the safebrowsing lookup.
-					sourcelist = append(sourcelist, "google-safebrowsing-api")
-				}
+				score = 1
+				sourcelist = append(sourcelist, "google-safebrowsing-api")
 			}
 		}
 

--- a/analysis/crossref/blacklisted.go
+++ b/analysis/crossref/blacklisted.go
@@ -1,0 +1,54 @@
+package crossref
+
+import (
+	"github.com/ocmdev/rita/analysis/blacklisted"
+	"github.com/ocmdev/rita/analysis/urls"
+	"github.com/ocmdev/rita/database"
+	blacklistedData "github.com/ocmdev/rita/datatypes/blacklisted"
+)
+
+type (
+	BlacklistedSelector struct{}
+)
+
+func (b BlacklistedSelector) GetName() string {
+	return "blacklisted"
+}
+
+func (b BlacklistedSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
+	// make channels to return
+	internalHosts := make(chan string)
+	externalHosts := make(chan string)
+	// run the read code async and return the channels immediately
+	go func() {
+		ssn := res.DB.Session.Copy()
+		defer ssn.Close()
+
+		iter := ssn.DB(res.DB.GetSelectedDB()).
+			C(res.System.BlacklistedConfig.BlacklistTable).Find(nil).Iter()
+
+		//iterate through blacklist table
+		var data blacklistedData.Blacklist
+		for iter.Next(&data) {
+
+			//load the ips of those who visited the blacklisted site into the struct
+			//and write them to xref
+			blacklisted.SetBlacklistSources(res, &data)
+			for _, src := range data.Sources {
+				internalHosts <- src
+			}
+
+			//write the blacklisted site to xref, handle hostname appropriately
+			if data.IsUrl {
+				for _, dst := range urls.GetIPsFromHost(res, data.Host) {
+					externalHosts <- dst
+				}
+			} else {
+				externalHosts <- data.Host
+			}
+		}
+		close(internalHosts)
+		close(externalHosts)
+	}()
+	return internalHosts, externalHosts
+}

--- a/analysis/crossref/scanning.go
+++ b/analysis/crossref/scanning.go
@@ -15,8 +15,8 @@ func (s ScanningSelector) GetName() string {
 
 func (s ScanningSelector) Select(res *database.Resources) (<-chan string, <-chan string) {
 	// make channels to return
-	internalHosts := make(chan string, 100)
-	externalHosts := make(chan string, 100)
+	internalHosts := make(chan string)
+	externalHosts := make(chan string)
 	// run the read code async and return the channels immediately
 	go func() {
 		ssn := res.DB.Session.Copy()

--- a/analysis/scanning/scan.go
+++ b/analysis/scanning/scan.go
@@ -20,9 +20,10 @@ func BuildScanningCollection(res *database.Resources) {
 		res.Log.Error("Failed: ", new_collection_name, error_check)
 		return
 	}
-
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
 	// Aggregate it!
-	res.DB.AggregateCollection(source_collection_name, pipeline)
+	res.DB.AggregateCollection(source_collection_name, ssn, pipeline)
 }
 
 func getScanningCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -24,7 +24,10 @@ func BuildHostsCollection(res *database.Resources) {
 		return
 	}
 
-	res.DB.AggregateCollection(source_collection_name, pipeline)
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	res.DB.AggregateCollection(source_collection_name, ssn, pipeline)
 }
 
 func getHosts(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/urls/url.go
+++ b/analysis/urls/url.go
@@ -28,8 +28,10 @@ func BuildUrlsCollection(res *database.Resources) {
 		return
 	}
 
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
 	// Aggregate it
-	res.DB.AggregateCollection(new_collection_name, pipeline)
+	res.DB.AggregateCollection(new_collection_name, ssn, pipeline)
 }
 
 func getUrlCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, mgo.MapReduce, []bson.D) {
@@ -76,6 +78,27 @@ func getUrlCollectionScript(sysCfg *config.SystemConfig) (string, string, []stri
 	return source_collection_name, new_collection_name, keys, job, pipeline
 }
 
+// GetIPsFromHost uses the hostnames table to do a cached whois query
+func GetIPsFromHost(res *database.Resources, host string) []string {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	hostnames := ssn.DB(res.DB.GetSelectedDB()).C(res.System.UrlsConfig.HostnamesTable)
+
+	//I don't know if this can be cleaned up
+	//TODO: Research of query projections
+	var destIPs struct {
+		IPs []string `bson:"ips"`
+	}
+	hostnames.Find(bson.M{"host": host}).One(&destIPs)
+
+	var ips []string
+	for _, ip := range destIPs.IPs {
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
 func BuildHostnamesCollection(res *database.Resources) {
 	source_collection_name,
 		new_collection_name,
@@ -88,7 +111,10 @@ func BuildHostnamesCollection(res *database.Resources) {
 		return
 	}
 
-	res.DB.AggregateCollection(source_collection_name, pipeline)
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	res.DB.AggregateCollection(source_collection_name, ssn, pipeline)
 }
 
 func getHostnamesAggregationScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/analysis/useragent/useragent.go
+++ b/analysis/useragent/useragent.go
@@ -21,8 +21,11 @@ func BuildUserAgentCollection(res *database.Resources) {
 		return
 	}
 
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
 	// Aggregate it!
-	res.DB.AggregateCollection(source_collection_name, pipeline)
+	res.DB.AggregateCollection(source_collection_name, ssn, pipeline)
 }
 
 func getUserAgentCollectionScript(sysCfg *config.SystemConfig) (string, string, []string, []bson.D) {

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -77,7 +77,7 @@ func cleanAnalysis(database string, res *database.Resources) error {
 func cleanAnalysisAll(res *database.Resources) error {
 	var err error = nil
 
-	for _, name := range res.MetaDB.GetAnalyzedDatabases() {
+	for _, name := range res.MetaDB.GetDatabases() {
 		e := cleanAnalysis(name, res)
 		//return last error
 		if e != nil {

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -43,7 +43,10 @@ func showBeacons(c *cli.Context) error {
 	res.DB.SelectDB(c.String("database"))
 
 	var data []tbdData.TBDAnalysisView
-	TBD.GetTBDResultsView(res, cutoffScore).All(&data)
+
+	ssn := res.DB.Session.Copy()
+	TBD.GetTBDResultsView(res, ssn, cutoffScore).All(&data)
+	ssn.Close()
 
 	if humanreadable {
 		return showBeaconReport(data)

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -43,7 +43,7 @@ func showBeacons(c *cli.Context) error {
 	res.DB.SelectDB(c.String("database"))
 
 	var data []tbdData.TBDAnalysisView
-	TBD.GetTBDResultsView(res, cutoffScore).All(data)
+	TBD.GetTBDResultsView(res, cutoffScore).All(&data)
 
 	if humanreadable {
 		return showBeaconReport(data)

--- a/commands/show-blacklisted.go
+++ b/commands/show-blacklisted.go
@@ -3,35 +3,24 @@ package commands
 import (
 	"fmt"
 	"os"
-	"sort"
+	"strconv"
+	"strings"
 
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/alecthomas/template"
 	"github.com/ocmdev/rita/database"
+	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 )
+
+var sourcesFlag bool
 
 type blresult struct {
 	Host    string `bson:"host"`
 	Score   int    `bson:"count"`
-	Sources string
-}
-
-var globalSourcesFlag bool
-
-type blresults []blresult
-
-func (slice blresults) Len() int {
-	return len(slice)
-}
-
-func (slice blresults) Less(i, j int) bool {
-	return slice[j].Score < slice[i].Score
-}
-
-func (slice blresults) Swap(i, j int) {
-	slice[i], slice[j] = slice[j], slice[i]
+	IsUrl   bool   `bson:"is_url"`
+	Sources []string
 }
 
 func init() {
@@ -44,7 +33,7 @@ func init() {
 			cli.BoolFlag{
 				Name:        "sources, s",
 				Usage:       "Show sources with results",
-				Destination: &globalSourcesFlag,
+				Destination: &sourcesFlag,
 			},
 		},
 		Action: showBlacklisted,
@@ -58,13 +47,85 @@ func showBlacklisted(c *cli.Context) error {
 		return cli.NewExitError("Specify a database with -d", -1)
 	}
 
-	if humanreadable {
-		return showBlacklistedHuman(c)
+	res := database.InitResources("")
+	res.DB.SelectDB(c.String("database"))
+
+	var result blresult
+	var results []blresult
+
+	coll := res.DB.Session.DB(c.String("database")).C(res.System.BlacklistedConfig.BlacklistTable)
+	iter := coll.Find(nil).Sort("-count").Iter()
+
+	for iter.Next(&result) {
+		if sourcesFlag {
+			findBLSources(res, c.String("database"), &result)
+		}
+		results = append(results, result)
 	}
 
+	if humanreadable {
+		return showBlacklistedHuman(results)
+	}
+	return showBlacklistedCsv(results)
+}
+
+func findBLSources(res *database.Resources, db string, result *blresult) {
+	if result.IsUrl {
+		hostnames := res.DB.Session.DB(db).C(res.System.UrlsConfig.HostnamesTable)
+		var destIPs struct {
+			IPs []string `bson:"ips"`
+		}
+		hostnames.Find(bson.M{"host": result.Host}).One(&destIPs)
+		for _, destIP := range destIPs.IPs {
+			result.Sources = append(result.Sources, getConnSourceFromDest(res, db, destIP)...)
+		}
+	} else {
+		result.Sources = getConnSourceFromDest(res, db, result.Host)
+	}
+}
+
+func getConnSourceFromDest(res *database.Resources, db string, ip string) []string {
+	cons := res.DB.Session.DB(db).C(res.System.StructureConfig.UniqueConnTable)
+	srcIter := cons.Find(bson.M{"dst": ip}).Iter()
+
+	var srcStruct struct {
+		Src string `bson:"src"`
+	}
+	var sources []string
+
+	for srcIter.Next(&srcStruct) {
+		sources = append(sources, srcStruct.Src)
+	}
+	return sources
+}
+
+// TODO: Convert this over to tablewriter
+// showBlacklisted prints all blacklisted for a given database
+func showBlacklistedHuman(results []blresult) error {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColWidth(100)
+	if sourcesFlag {
+		table.SetHeader([]string{"Host", "Score", "Sources"})
+		for _, result := range results {
+			table.Append([]string{
+				result.Host, strconv.Itoa(result.Score), strings.Join(result.Sources, ", "),
+			})
+		}
+	} else {
+		table.SetHeader([]string{"Host", "Score"})
+		for _, result := range results {
+			table.Append([]string{result.Host, strconv.Itoa(result.Score)})
+		}
+	}
+
+	table.Render()
+	return nil
+}
+
+func showBlacklistedCsv(results []blresult) error {
 	tmpl := "{{.Host}}," + `{{.Score}}`
-	if globalSourcesFlag {
-		tmpl += ", {{.Sources}}\n"
+	if sourcesFlag {
+		tmpl += ",{{range $idx, $src := .Sources}}{{if $idx}} {{end}}{{ $src }}{{end}}\n"
 	} else {
 		tmpl += "\n"
 	}
@@ -73,77 +134,12 @@ func showBlacklisted(c *cli.Context) error {
 		panic(err)
 	}
 
-	res := database.InitResources("")
-	res.DB.SelectDB(c.String("database"))
-
-	var result blresult
-	var allResults blresults
-
-	coll := res.DB.Session.DB(c.String("database")).C(res.System.BlacklistedConfig.BlacklistTable)
-	iter := coll.Find(nil).Iter()
-
-	for iter.Next(&result) {
-		if globalSourcesFlag {
-			result.Sources = ""
-			cons := res.DB.Session.DB(c.String("database")).C(res.System.StructureConfig.ConnTable)
-			siter := cons.Find(bson.M{"id_resp_h": result.Host}).Iter()
-
-			var srcStruct struct {
-				Src string `bson:"id_origin_h"`
-			}
-
-			for siter.Next(&srcStruct) {
-				result.Sources += srcStruct.Src + "; "
-			}
-		}
-		allResults = append(allResults, result)
-	}
-
-	sort.Sort(allResults)
-
-	for _, result := range allResults {
+	for _, result := range results {
 		err := out.Execute(os.Stdout, result)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
 		}
 	}
-	return nil
-}
 
-// TODO: Convert this over to tablewriter
-// showBlacklisted prints all blacklisted for a given database
-func showBlacklistedHuman(c *cli.Context) error {
-
-	cols := "            host\tscore\n"
-	cols += "----------------\t-----\n"
-	tmpl := "{{.Host}}\t" + `{{.Score | printf "%5d"}}` + "\n"
-	out, err := template.New("bl").Parse(tmpl)
-	if err != nil {
-		panic(err)
-	}
-
-	res := database.InitResources("")
-	res.DB.SelectDB(c.String("database"))
-
-	var result blresult
-	var allResults blresults
-
-	coll := res.DB.Session.DB(c.String("database")).C(res.System.BlacklistedConfig.BlacklistTable)
-	iter := coll.Find(nil).Iter()
-
-	fmt.Printf(cols)
-	for iter.Next(&result) {
-		result.Host = padAddr(result.Host)
-		allResults = append(allResults, result)
-	}
-
-	sort.Sort(allResults)
-
-	for _, result := range allResults {
-		err := out.Execute(os.Stdout, result)
-		if err != nil {
-			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
-		}
-	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -117,12 +117,12 @@ func GetConfig(cfgPath string) (*SystemConfig, bool) {
 		fmt.Fprintf(os.Stderr, "Could not get user info: %s\n", err.Error())
 	} else {
 
-		conf, ok := LoadSystemConfig(user.HomeDir + "/.rita")
+		conf, ok := LoadSystemConfig(user.HomeDir + "/.rita/config.yaml")
 		if ok {
 			return conf, ok
 		}
 	}
 
-	// If none of the other configs have worked, go for the homedir config
+	// If none of the other configs have worked, go for the global config
 	return LoadSystemConfig("/etc/rita/config.yaml")
 }

--- a/database/control.go
+++ b/database/control.go
@@ -104,15 +104,8 @@ func (d *DB) CreateCollection(name string, indeces []string) string {
  * Purpose:  Builds collections that are built via aggregation
  * comments:
  */
-func (d *DB) AggregateCollection(source_collection_name string, pipeline []bson.D) *mgo.Iter {
-	// Make a copy of the current session
-	session := d.Session.Copy()
-	defer session.Close()
-
+func (d *DB) AggregateCollection(source_collection_name string, session *mgo.Session, pipeline []bson.D) *mgo.Iter {
 	session.SetSocketTimeout(2 * time.Hour)
-
-	// Setup a container for the results
-	// results := []bson.D{}
 
 	// Identify the source collection we will aggregate information from into the new collection
 	if !d.CollectionExists(source_collection_name) {

--- a/datatypes/blacklisted/blacklisted.go
+++ b/datatypes/blacklisted/blacklisted.go
@@ -14,5 +14,6 @@ type (
 		IsUrl           bool          `bson:"is_url"`
 		IsIp            bool          `bson:"is_ip"`
 		BlacklistSource []string      `bson:"blacklist_sources"`
+		Sources         []string      `bson:"sources,omitempty"`
 	}
 )

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -6,7 +6,7 @@ DatabaseHost: localhost:27017
 # 2 = info
 # 1 = warn
 # 0 = error
-LogLevel: 2
+LogLevel: 1
 
 # Adjusting batchsize and prefetch may help speed up certain database queries
 BatchSize: 300
@@ -66,7 +66,7 @@ Bro:
 
 SafeBrowsing:
     APIKey: ""
-    Database: ~/.rita/safebrowsing
+    Database: $HOME/.rita/safebrowsing
 
 # NOTE: DO NOT CHANGE THE SETTINGS BELOW UNLESS YOU ARE FAMILIAR WITH THE CODE #
 Structure:

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -66,7 +66,7 @@ Bro:
 
 SafeBrowsing:
     APIKey: ""
-    Database: /usr/local/rita/safebrowsing_database
+    Database: ~/.rita/safebrowsing
 
 # NOTE: DO NOT CHANGE THE SETTINGS BELOW UNLESS YOU ARE FAMILIAR WITH THE CODE #
 Structure:

--- a/install.sh
+++ b/install.sh
@@ -170,7 +170,6 @@ install the correct version for you!
 	# Install the base configuration file
 	printf "[+] Installing config to $HOME/.rita/config.yaml\n\n"
 	mkdir $HOME/.rita
-	mkdir $HOME/.rita/safebrowsing
 	cp etc/rita.yaml $HOME/.rita/config.yaml
 	
 

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,6 @@ _NAME=$(basename "${0}")
 _INSDIR="/usr/local"
 
 __help() {
-	__title
 	cat <<HEREDOC
 
 Welcome to the RITA installer.
@@ -20,8 +19,9 @@ Usage:
 	${_NAME} -h | --help
 
 Options:
-	-h --help 		Show this help message.
-	-i --install-dir	Directory to install to.
+	-h --help			Show this help message.
+	-i --install-dir		Directory to install to.
+	-u --uninstall			Remove RITA.
 
 HEREDOC
 }
@@ -43,135 +43,143 @@ HEREDOC
 
 __title() {
 	cat <<HEREDOC
-
- _ \ _ _| __ __|  \
-   /   |     |   _ \
-_|_\ ___|   _| _/  _\
+ _ \ _ _| __ __|  \ 
+   /   |     |   _ \ 
+_|_\ ___|   _| _/  _\ 
 
 Brought to you by the Offensive CounterMeasures
 
 HEREDOC
 }
 
-__install() {
-	__title
+__uninstall() {
+	printf "Removing $_RITADIR \n"
+	rm -rf $_RITADIR
+	printf "Removing $GOPATH/bin/rita \n"
+	rm -rf $GOPATH/bin/rita
+	printf "Removing $GOPATH/src/github.com/ocmdev \n"
+	rm -rf $GOPATH/src/github.com/ocmdev
+	printf "Removing /etc/rita \n"
+	rm -rf /etc/rita
+}
 
-	_RITADIR="$_INSDIR/rita"
+__install() {
 	if [ -e $_RITADIR ]
 	then
 		printf "[+] $_RITADIR already exists.\n"
-		read -p "     [-] Would you like to erase it and re-install? [y/n] " -n 1 -r
+		read -p "[-] Would you like to erase it and re-install? [y/n] " -n 1 -r
 		if [[ $REPLY =~ ^[Yy]$ ]]
 		then
-			printf "\n[+] Removing $_RITADIR\n"
-			rm -rf $_RITADIR
+			__uninstall
 		else
 			exit -1
 		fi
 	fi
-
-  sudo apt update
-
-  sudo apt install -y bro
-  sudo apt install -y broctl
-  sudo apt install -y build-essential
-
-  # golang most recent update
-  wget https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
-  sudo tar -zxvf  go1.7.1.linux-amd64.tar.gz -C /usr/local/
-  sudo rm go1.7.1.linux-amd64.tar.gz
-
-  echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-
-  echo -e "
-[+] Done! Now just need to configure Go dev environment...
-
-  \e[0m"
-
-  sleep 3s
-
-  if [[ -z "${GOPATH}" ]];
-  then
-    mkdir -p $HOME/go/{src,pkg,bin}
-    echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc
-    export GOPATH=$HOME/go
-    echo 'export PATH=$PATH:$GOPATH/bin' >> $HOME/.bashrc
-    export PATH=$PATH:$GOPATH/bin
-  else
-    echo -e "[+] GOPATH seems to be set, we'll skip this part then for now
-    "
-  fi
-
-  echo -e "[+] Now we need to get package key and MongoDB package...
+	
+	echo "[+] Updating apt...
 "
 
-  sleep 3s
+	apt -qq update
 
-  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-
-  echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
-
-  sudo apt update
-  sudo apt install -y mongodb-org
-
-  sudo mkdir -p /data/db
-  sudo chown -R $USER /data
-
-  printf "[+] Running 'go get github.com/ocmdev/rita'\n\n"
-
-  /usr/local/go/bin/go get github.com/ocmdev/rita
-  cd $GOPATH/src/github.com/ocmdev/rita
-
-  printf "[+] Done! Now we just have to build and install RITA.\n"
-  /usr/local/go/bin/go build
-  /usr/local/go/bin/go install
-
-  echo "[+] Make sure you also configure Bro and run with 'sudo broctl deploy' and make sure MongoDB is running with the command 'mongo' or 'sudo mongo'.
+	echo "
+[+] Ensuring bro is installed...
 "
 
+	apt install -y bro
+	apt install -y broctl
 
-
-  echo -e "
-[+] If you need to stop Mongo at any time, run 'sudo service mongod stop'
-[+] In order to finish the installation, reload bash config with 'source ~/.bashrc'.
-[+] Also make sure to start the mongoDB service with 'sudo service mongod start before running RITA.
-[+] You can access the mongo shell with 'sudo mongo'
+	echo "
+[+] Ensuring go is installed...
 "
 
-	printf "[+] Transferring files\n"
+	if [ ! $(command -v go) ]
+	then
+		if [ ! -e "/usr/local/go" ]
+		then
+			# golang most recent update
+			wget https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
+			tar -zxf go1.7.1.linux-amd64.tar.gz -C /usr/local/
+			echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bashrc
+			rm go1.7.1.linux-amd64.tar.gz
+		fi
+		export PATH="$PATH:/usr/local/go/bin"
+	else
+		echo -e "\e[31m[-] WARNING: Go has been detected on this system,\e[37m if you
+installed with apt, RITA has only been tested with golang 1.7 which is currently not the
+version in the Ubuntu apt repositories, make sure your golang is up to date
+with 'go version'. Otherwise you can remove with 'sudo apt remove golang' and let this script
+install the correct version for you!"
+		
+		sleep 10s
+	fi
+
+
+	echo -e "
+[+] Configuring Go dev environment...
+\e[0m"
+
+	sleep 3s
+
+	if [ -z "${GOPATH}" ]
+	then
+		mkdir -p $HOME/go/{src,pkg,bin}
+		echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc
+		export GOPATH=$HOME/go
+		echo 'export PATH=$PATH:$GOPATH/bin' >> $HOME/.bashrc
+		export PATH=$PATH:$GOPATH/bin
+	else
+		echo -e "[-] GOPATH seems to be set, we'll skip this part then for now
+		"
+	fi
+
+	echo -e "[+] Getting the package key and install package for MongoDB...
+"
+
+	sleep 3s
+
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+
+	echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" > /etc/apt/sources.list.d/mongodb-org-3.4.list
+
+	apt -qq update
+	apt install -y mongodb-org
+
+	printf "\n[+] Running 'go get github.com/ocmdev/rita...'\n\n"
+	
+	go get github.com/ocmdev/rita
+	printf "[+] Installing RITA...\n\n"
+	cd $GOPATH/src/github.com/ocmdev/rita
+	go build
+	go install
+
+	printf "[+] Transferring files...\n\n"
 	mkdir $_RITADIR
 
 	cp -r etc $_RITADIR/etc
 	cp LICENSE $_RITADIR/LICENSE
 
 	# Install the base configuration file
-	if [ -w /etc/ ]
+	if [ ! -e /etc/rita ]
 	then
-		if [ ! -e /etc/rita ]
-		then
-			printf "[+] Installing global config to /etc/rita/config.yaml"
-			mkdir /etc/rita
-			cp etc/rita.yaml /etc/rita/config.yaml
-		fi
-	else
-		if [ ! -e $HOME/.rita ]
-		then
-			printf "[+] Could not write to /etc installing local config in $HOME/.rita\n"
-			cp etc/rita.yaml $HOME/.rita
-		fi
+		printf "[+] Installing global config to /etc/rita/config.yaml\n\n"
+		mkdir /etc/rita
+		cp etc/rita.yaml /etc/rita/config.yaml
 	fi
 
-  printf "[+] Installing gnu-netcat to /usr/local/rita\n"
-  # gnu-netcat
-  wget https://sourceforge.net/projects/netcat/files/netcat/0.7.1/netcat-0.7.1.tar.gz
-  tar -zxf netcat-0.7.1.tar.gz
-  rm netcat-0.7.1.tar.gz
-  cd netcat-0.7.1
-  ./configure --prefix=/usr/local/rita
-  sudo make
-  sudo make install
-  cd ..
-  rm -rf netcat-0.7.1
+	# Give ownership of ~/go to the user
+	sudo chown -R $SUDO_USER:$SUDO_USER /home/$SUDO_USER/go
+
+	echo "[+] Make sure you also configure Bro and run with 'sudo broctl deploy' and make sure MongoDB is running with the command 'mongo' or 'sudo mongo'.
+"
+
+	echo -e "[+] If you need to stop Mongo at any time, run 'sudo service mongod stop'
+[+] In order to finish the installation, reload bash config with 'source ~/.bashrc'.
+[+] Also make sure to start the mongoDB service with 'sudo service mongod start before running RITA.
+[+] You can access the mongo shell with 'sudo mongo'
+"
+
+	echo -e "[+] You may need to source your .bashrc before you call RITA!
+"
 
 	printf "Thank you for installing RITA!\n"
 	printf "OCMDev Group projects IRC #ocmdev on OFTC\n"
@@ -186,15 +194,28 @@ __entry() {
 	if [[ "${1:-}" =~ ^-h|--help$ ]]
 	then
 		__help
-	elif [[ "${1:-}" =~ ^-i|--install-dir ]]
+		exit 0
+	fi
+
+	if [[ "${1:-}" =~ ^-i|--install-dir ]]
 	then
 		_INSDIR=$( echo "${@}" | cut -d' ' -f2 )
 	fi
+	
+	# Set the rita directory	
+	_RITADIR="$_INSDIR/rita"
+	
 
 	# Check to see if the user has permission to install to this directory
 	if [ -w $_INSDIR ]
 	then
-		__install
+		# Check if we are uninstalling
+		if [[ "${1:-}" =~ ^-u|--uninstall ]]
+		then
+			__uninstall
+		else
+			__install
+		fi
 	else
 		printf "You do NOT have permission to write to $_INSDIR\n\n"
 		__help


### PR DESCRIPTION
- Add Ben LeBrun's additions to the installer.
- Fix installer for sudo ./install paradigm, removed netcat.
- Added uninstaller to the installer script.
- Moved user config to ~/.rita/config.yaml.
- Moved safebrowsing db to ~/.rita/safebrowsing
- Allow for use of environment variables in the RITA config (this is pretty neat!) 
- Blacklisted was adding the ip addresses from the hostnames table as well as hosts, this created duplicate entries
- Fixed a regression in show-beacons from the aggregation fix that came with crossref.
- Fixed a bug where reset-analysis would only reset a database if analysis had succeeded on that database.
- Rewrote the blacklisted output for pretty printing and for accurately finding the ip's of the computers that visited the blacklisted sites.
- Lowered default log level in preparation for release.
- Added the instructions to enable the safe browsing api for google
- Fixed crossref deadlock
- Fixed iterating over closed session on aggregations 
- Changed schema of crossref to ip string, modules []string
- Added blacklist to crossref
- Tested against several large datasets