### PR TITLE
Added basic support for Bro's collection types

### DIFF
--- a/database/meta.go
+++ b/database/meta.go
@@ -76,6 +76,7 @@ func (m *MetaDBHandle) AddNewDB(name string) error {
 	newRes.DB = &DB{Session: m.res.DB.Session, resources: &newRes, selected: name}
 	buildConnectionsCollection(&newRes)
 	buildHttpCollection(&newRes)
+	buildDNSCollection(&newRes)
 	m.logDebug("AddNewDB", "exiting")
 	return nil
 }

--- a/parser/conn.go
+++ b/parser/conn.go
@@ -52,7 +52,7 @@ type (
 		// RespIpBytes gives the bytecount of response data
 		RespIPBytes int64 `bson:"resp_ip_bytes" bro:"resp_ip_bytes" brotype:"count"`
 		// TunnelParents lists tunnel parents
-		TunnelParents string `bson:"tunnel_parents" bro:"tunnel_parents" brotype:"set[string]"`
+		TunnelParents []string `bson:"tunnel_parents" bro:"tunnel_parents" brotype:"set[string]"`
 	}
 )
 

--- a/parser/dns.go
+++ b/parser/dns.go
@@ -54,9 +54,9 @@ type DNS struct {
 	// Z represents the state of a reseverd field that should be zero in qll queries
 	Z int64 `bson:"Z" bro:"Z" brotype:"count"`
 	// Answers contains the set of resource descriptions in the query answer
-	Answers string `bson:"answers" bro:"answers" brotype:"vector[string]"`
+	Answers []string `bson:"answers" bro:"answers" brotype:"vector[string]"`
 	// TTLs contians a vector of interval type time to live values
-	TTLs string `bson:"TTLs" bro:"TTLs" brotype:"vector[interval]"`
+	TTLs []float64 `bson:"TTLs" bro:"TTLs" brotype:"vector[interval]"`
 	// Rejected indicates if this query was rejected or not
 	Rejected bool `bson:"rejected" bro:"rejected" brotype:"bool"`
 }

--- a/parser/http.go
+++ b/parser/http.go
@@ -56,19 +56,19 @@ type HTTP struct {
 	// Password will contain a password in the case of basic auth implementation
 	Password string `bson:"password" bro:"password" brotype:"string"`
 	// Proxied contains all headers that indicate a request was proxied
-	Proxied string `bson:"proxied" bro:"proxied" brotype:"set[string]"`
+	Proxied []string `bson:"proxied" bro:"proxied" brotype:"set[string]"`
 	// OrigFuids contains an ordered vector of uniq file IDs
-	OrigFuids string `bson:"orig_fuids" bro:"orig_fuids" brotype:"vector[string]"`
+	OrigFuids []string `bson:"orig_fuids" bro:"orig_fuids" brotype:"vector[string]"`
 	// OrigFilenames contains an ordered vector of filenames from the client
-	OrigFilenames string `bson:"orig_filenames" bro:"orig_filenames" brotype:"vector[string]"`
+	OrigFilenames []string `bson:"orig_filenames" bro:"orig_filenames" brotype:"vector[string]"`
 	// OrigMimeTypes contains an ordered vector of mimetypes
-	OrigMimeTypes string `bson:"orig_mime_types" bro:"orig_mime_types" brotype:"vector[string]"`
+	OrigMimeTypes []string `bson:"orig_mime_types" bro:"orig_mime_types" brotype:"vector[string]"`
 	// RespFuids contains an ordered vector of unique file IDs in the response
-	RespFuids string `bson:"resp_fuids" bro:"resp_fuids" brotype:"vector[string]"`
+	RespFuids []string `bson:"resp_fuids" bro:"resp_fuids" brotype:"vector[string]"`
 	// RespFilenames contains an ordered vector of unique files in the response
-	RespFilenames string `bson:"resp_filenames" bro:"resp_filenames" brotype:"vector[string]"`
+	RespFilenames []string `bson:"resp_filenames" bro:"resp_filenames" brotype:"vector[string]"`
 	// RespMimeTypes contains an ordered vector of unique MIME entities in the HTTP response body
-	RespMimeTypes string `bson:"resp_mime_types" bro:"resp_mime_types" brotype:"vector[string]"`
+	RespMimeTypes []string `bson:"resp_mime_types" bro:"resp_mime_types" brotype:"vector[string]"`
 }
 
 func (in *HTTP) TargetCollection() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -233,20 +233,41 @@ func (d *docParser) parseLine() {
 				}
 				data.Field(d.SFields[val]).SetBool(false)
 				break
-			case "set[string]":
-				data.Field(d.SFields[val]).SetString(line[idx])
+			case STRING_SET:
+				tokens := strings.Split(line[idx], ",")
+				tVal := reflect.ValueOf(tokens)
+				data.Field(d.SFields[val]).Set(tVal)
 				break
-			case "set[enum]":
-				data.Field(d.SFields[val]).SetString(line[idx])
+			case ENUM_SET:
+				tokens := strings.Split(line[idx], ",")
+				tVal := reflect.ValueOf(tokens)
+				data.Field(d.SFields[val]).Set(tVal)
 				break
-			case "vector[string]":
-				data.Field(d.SFields[val]).SetString(line[idx])
+			case STRING_VECTOR:
+				tokens := strings.Split(line[idx], ",")
+				tVal := reflect.ValueOf(tokens)
+				data.Field(d.SFields[val]).Set(tVal)
 				break
-			case "vector[duration]":
-				data.Field(d.SFields[val]).SetString(line[idx])
-				break
-			case "vector[interval]":
-				data.Field(d.SFields[val]).SetString(line[idx])
+			//case DURATION_VECTOR:
+			//	data.Field(d.SFields[val]).SetString(line[idx])
+			//	break
+			case INTERVAL_VECTOR:
+				tokens := strings.Split(line[idx], ",")
+				floats := make([]float64, len(tokens))
+				for i, val := range tokens {
+					var err error
+					floats[i], err = strconv.ParseFloat(val, 64)
+					if err != nil {
+						d.log.WithFields(log.Fields{
+							"error": err.Error(),
+							"value": val,
+						}).Error("Couldn't convert float")
+						data.Field(d.SFields[val]).SetFloat(-1.0)
+						break
+					}
+				}
+				fVal := reflect.ValueOf(floats)
+				data.Field(d.SFields[val]).Set(fVal)
 				break
 			default:
 				d.log.WithFields(log.Fields{

--- a/parser/parsertypes.go
+++ b/parser/parsertypes.go
@@ -70,18 +70,30 @@ const (
 	// TABLE represents an associated array that maps from one set of
 	// values to another. Values being mapped are refered to as indices and
 	// the resulting map the yield.
-	TABLE = "table"
+	//TABLE = "table"
 
 	// SET is like table but the collection of indicies do not have to map
 	// to any yield value.
-	SET = "set"
+	//SET = "set"
 
 	// VECTOR is a table which is always mapped by its count.
-	VECTOR = "vector"
+	//VECTOR = "vector"
 
 	// RECORD represents a collection of values each with a field name and
 	// type.
-	RECORD = "record"
+	//RECORD = "record"
+
+	// STRING_SET is a SET which contains STRINGs
+	STRING_SET = "set[string]"
+
+	// ENUM_SET is a SET which contains ENUMs
+	ENUM_SET = "set[enum]"
+
+	// STRING_VECTOR is a VECTOR which contains STRINGs
+	STRING_VECTOR = "vector[string]"
+
+	// INTERVAL_VECTOR is a VECTOR which contains INTERVALs
+	INTERVAL_VECTOR = "vector[interval]"
 
 	// FUNCTION represents a function type in bro script.
 	FUNCTION = "function"


### PR DESCRIPTION
Previously in the parser, we were parsing in bro's collections as strings which prevented us from performing analysis on DNS logs. Also the dns collection wasn't being properly built/ indexed. This addition has been tested on several (4+) datasets.

Note: this will be the start of a new dev branch on the ocmdev repo.