### PR TITLE
Exploded dns analysis

### DIFF
--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -1,0 +1,50 @@
+package dns
+
+import (
+	"github.com/ocmdev/rita/database"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var tempVistedCountCollName string = "__temp_ExplodedDNSVistedCounts"
+var tempUniqSubdomainCollName string = "__temp_UniqSubdomains"
+
+// BuildExplodedDNSCollection splits domain names into sub-domains
+// and performs analysis
+func BuildExplodedDNSCollection(res *database.Resources) {
+	buildExplodedDNSVistedCounts(res)
+	buildExplodedDNSUniqSubdomains(res)
+	zipExplodedDNSResults(res)
+}
+
+func buildExplodedDNSVistedCounts(res *database.Resources) {
+	res.DB.MapReduceCollection(
+		res.System.StructureConfig.DnsTable,
+		mgo.MapReduce{
+			Map: `function() {
+              var dots = [];
+              //find all subdomain seperators
+              for (i = 0; i < this.query.length; i++) {
+                  if (this.query[i] == '.') {
+                      dots.push(i);
+                  }
+              }
+              for (i = 0; i < dots.length; i++) {
+                  emit(this.query.substring(dots[i] + 1), 1);
+              }
+            }`,
+			Reduce: `function(subdomain, countArr) {
+                return Array.sum(countArr);
+               }`,
+			Out: bson.M{"replace": tempVistedCountCollName},
+		},
+	)
+}
+
+func buildExplodedDNSUniqSubdomains(res *database.Resources) {
+
+}
+
+func zipExplodedDNSResults(res *database.Resources) {
+
+}

--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -15,6 +15,10 @@ func BuildExplodedDNSCollection(res *database.Resources) {
 	buildExplodedDNSVistedCounts(res)
 	buildExplodedDNSUniqSubdomains(res)
 	zipExplodedDNSResults(res)
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+	ssn.DB(res.DB.GetSelectedDB()).C(tempVistedCountCollName).DropCollection()
+	ssn.DB(res.DB.GetSelectedDB()).C(tempUniqSubdomainCollName).DropCollection()
 }
 
 // buildExplodedDNSVistedCounts uses the map reduce job to count how many

--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -17,34 +17,89 @@ func BuildExplodedDNSCollection(res *database.Resources) {
 	zipExplodedDNSResults(res)
 }
 
+// buildExplodedDNSVistedCounts uses the map reduce job to count how many
+// times each super domain was visited
 func buildExplodedDNSVistedCounts(res *database.Resources) {
 	res.DB.MapReduceCollection(
 		res.System.StructureConfig.DnsTable,
 		mgo.MapReduce{
-			Map: `function() {
-              var dots = [];
-              //find all subdomain seperators
-              for (i = 0; i < this.query.length; i++) {
-                  if (this.query[i] == '.') {
-                      dots.push(i);
-                  }
-              }
-              for (i = 0; i < dots.length; i++) {
-                  emit(this.query.substring(dots[i] + 1), 1);
-              }
-            }`,
-			Reduce: `function(subdomain, countArr) {
-                return Array.sum(countArr);
-               }`,
-			Out: bson.M{"replace": tempVistedCountCollName},
+			Map:    getExplodedDNSMapper("query"),
+			Reduce: getExplodedDNSReducer(),
+			Out:    bson.M{"replace": tempVistedCountCollName},
 		},
 	)
 }
 
+// buildExplodedDNSUniqSubdomains uses the map reduce job to count how many
+// unique subdomains exist for a given super domain
 func buildExplodedDNSUniqSubdomains(res *database.Resources) {
-
+	res.DB.MapReduceCollection(
+		tempVistedCountCollName,
+		mgo.MapReduce{
+			Map:    getExplodedDNSMapper("_id"),
+			Reduce: getExplodedDNSReducer(),
+			Out:    bson.M{"replace": tempUniqSubdomainCollName},
+		},
+	)
 }
 
 func zipExplodedDNSResults(res *database.Resources) {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+	res.DB.CreateCollection(res.System.DnsConfig.ExplodedDnsTable, []string{"domain"})
+	res.DB.AggregateCollection(tempVistedCountCollName, ssn,
+		[]bson.D{
+			{
+				{"$lookup", bson.D{
+					{"from", tempUniqSubdomainCollName},
+					{"localField", "_id"},
+					{"foreignField", "_id"},
+					{"as", "subdomains"},
+				}},
+			},
+			{
+				{"$unwind", "$subdomains"},
+			},
+			{
+				{"$project", bson.D{
+					{"_id", 0},
+					{"domain", "$_id"},
+					{"visited", "$value"},
+					{"subdomains", "$subdomains.value"},
+				}},
+			},
+			{
+				{"$out", res.System.DnsConfig.ExplodedDnsTable},
+			},
+		},
+	)
+}
 
+//Inserting a variable into a javascript function what could go wrong
+
+// getExplodedDNSMapper creates on O(N) map reduce job which
+// grabs all of the superdomains from a fqdn e.g. maps.google.com produces
+// maps.google.com, google.com, and com
+func getExplodedDNSMapper(nameField string) string {
+	return `function() {
+		var dots = [];
+		var domain = this.` + nameField + `.toLowerCase();
+		//find all subdomain separators
+		for (i = 0; i < domain.length; i++) {
+				if (domain[i] == '.') {
+						dots.push(i);
+				}
+		}
+		//emit all of the "super domains"
+		emit(domain, 1);
+		for (i = 0; i < dots.length; i++) {
+				emit(domain.substring(dots[i] + 1), 1);
+		}
+	}`
+}
+
+func getExplodedDNSReducer() string {
+	return `function(subdomain, countArr) {
+						return Array.sum(countArr);
+					}`
 }

--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -52,7 +52,7 @@ func buildExplodedDNSUniqSubdomains(res *database.Resources) {
 func zipExplodedDNSResults(res *database.Resources) {
 	ssn := res.DB.Session.Copy()
 	defer ssn.Close()
-	res.DB.CreateCollection(res.System.DnsConfig.ExplodedDnsTable, []string{"domain"})
+	res.DB.CreateCollection(res.System.DnsConfig.ExplodedDnsTable, []string{"domain", "subdomains"})
 	res.DB.AggregateCollection(tempVistedCountCollName, ssn,
 		[]bson.D{
 			{

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ocmdev/rita/analysis/beacon"
 	"github.com/ocmdev/rita/analysis/blacklisted"
 	"github.com/ocmdev/rita/analysis/crossref"
+	"github.com/ocmdev/rita/analysis/dns"
 	"github.com/ocmdev/rita/analysis/scanning"
 	"github.com/ocmdev/rita/analysis/structure"
 	"github.com/ocmdev/rita/analysis/urls"
@@ -88,6 +89,10 @@ func analyze(inDb string, configFile string) {
 		urls.BuildHostnamesCollection(res)
 
 		// Module Collections
+
+		fmt.Fprintf(os.Stdout, "\t[-] Running dns analysis\n")
+		dns.BuildExplodedDNSCollection(res)
+
 		fmt.Fprintf(os.Stdout,
 			"\t[-] Running beacon analysis\n")
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -38,6 +38,11 @@ var (
 		Name:  "human-readable, H",
 		Usage: "print a report instead of csv",
 	}
+
+	allFlag = cli.BoolFlag{
+		Name:  "all, a",
+		Usage: "print all available records",
+	}
 )
 
 // bootstrapCommands simply adds a given command to the allCommands array

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -13,8 +13,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var cutoffScore float64
-
 func init() {
 	command := cli.Command{
 		Name:  "show-beacons",
@@ -22,12 +20,7 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			cli.Float64Flag{
-				Name:        "score, s",
-				Usage:       "change the beacon cutoff score",
-				Destination: &cutoffScore,
-				Value:       .7,
-			},
+			allFlag,
 		},
 		Action: showBeacons,
 	}
@@ -43,6 +36,10 @@ func showBeacons(c *cli.Context) error {
 	res.DB.SelectDB(c.String("database"))
 
 	var data []beaconData.BeaconAnalysisView
+	cutoffScore := .7
+	if c.Bool("all") {
+		cutoffScore = 0
+	}
 
 	ssn := res.DB.Session.Copy()
 	beacon.GetBeaconResultsView(res, ssn, cutoffScore).All(&data)

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"text/template"
+
+	"github.com/ocmdev/rita/database"
+	"github.com/ocmdev/rita/datatypes/dns"
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli"
+)
+
+func init() {
+	command := cli.Command{
+
+		Name:  "show-exploded-dns",
+		Usage: "Print dns analysis. Exposes covert dns channels.",
+		Flags: []cli.Flag{
+			humanFlag,
+			databaseFlag,
+			allFlag,
+		},
+		Action: func(c *cli.Context) error {
+			if c.String("database") == "" {
+				return cli.NewExitError("Specify a database with -d", -1)
+			}
+
+			res := database.InitResources("")
+
+			var explodedResults []dns.ExplodedDNS
+			iter := res.DB.Session.DB(c.String("database")).C(res.System.DnsConfig.ExplodedDnsTable).Find(nil)
+			count, _ := iter.Count()
+
+			if !c.Bool("all") {
+				count = 15
+			}
+
+			iter.Sort("-subdomains").Limit(count).All(&explodedResults)
+
+			if c.Bool("human-readable") {
+				return showResultsHuman(explodedResults)
+			}
+			return showResults(explodedResults)
+		},
+	}
+	bootstrapCommands(command)
+}
+
+func showResults(dnsResults []dns.ExplodedDNS) error {
+	tmpl := "{{.Domain}},{{.Subdomains}},{{.Visited}}\n"
+
+	out, err := template.New("exploded-dns").Parse(tmpl)
+	if err != nil {
+		panic(err)
+	}
+
+	var error error = nil
+	for _, result := range dnsResults {
+		err := out.Execute(os.Stdout, result)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
+			error = err
+		}
+	}
+	return error
+}
+
+func showResultsHuman(dnsResults []dns.ExplodedDNS) error {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Domain", "Unique Subdomains", "Times Looked Up"})
+	for _, result := range dnsResults {
+		table.Append([]string{
+			result.Domain,
+			strconv.FormatInt(result.Subdomains, 10),
+			strconv.FormatInt(result.Visited, 10),
+		})
+	}
+	table.Render()
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type (
 		ImportWhitelist   bool            `yaml:"ImportWhitelist"`
 		RitaLogPath       string          `yaml:"RitaLogPath"`
 		BlacklistedConfig BlacklistedCfg  `yaml:"BlackListed"`
+		DnsConfig         DnsCfg          `yaml:"Dns"`
 		CrossrefConfig    CrossrefCfg     `yaml:"Crossref"`
 		ScanningConfig    ScanningCfg     `yaml:"Scanning"`
 		StructureConfig   StructureCfg    `yaml:"Structure"`
@@ -48,6 +49,10 @@ type (
 		ChannelSize       int    `yaml:"ChannelSize"`
 		BlacklistTable    string `yaml:"BlackListTable"`
 		BlacklistDatabase string `yaml:"Database"`
+	}
+
+	DnsCfg struct {
+		ExplodedDnsTable string `yaml:"ExplodedDnsTable"`
 	}
 
 	CrossrefCfg struct {

--- a/datatypes/data/data.go
+++ b/datatypes/data/data.go
@@ -19,4 +19,21 @@ type (
 		LocalSrc bool          `bson:"local_orig,omitempty"`
 		LocalDst bool          `bson:"local_resp,omitempty"`
 	}
+
+	// DNS provides structure for a subset of the fields in the
+	// parser.DNS data structure. If fields are needed that are
+	// not in this Conn structure use parser.DNS instead.
+	DNS struct {
+		ID      bson.ObjectId `bson:"_id,omitempty"`
+		Ts      int64         `bson:"ts"`
+		UID     string        `bson:"uid"`
+		Src     string        `bson:"id_origin_h"`
+		Spt     int           `bson:"id_origin_p"`
+		Dst     string        `bson:"id_resp_h"`
+		Dpt     int           `bson:"id_resp_p"`
+		Proto   string        `bson:"proto"`
+		QType   string        `bson:"qtype_name"`
+		Query   string        `bson:"query"`
+		Answers []string      `bson:"answers"`
+	}
 )

--- a/datatypes/dns.go
+++ b/datatypes/dns.go
@@ -1,0 +1,12 @@
+package dns
+
+import "gopkg.in/mgo.v2/bson"
+
+type (
+	ExplodedDNS struct {
+		ID         bson.ObjectId `bson:"_id,omitempty"`
+		Domain     string        `bson:"domain"`
+		Subdomains float64       `bson:"subdomains"`
+		Visited    float64       `bson:"visited"`
+	}
+)

--- a/datatypes/dns/dns.go
+++ b/datatypes/dns/dns.go
@@ -6,7 +6,7 @@ type (
 	ExplodedDNS struct {
 		ID         bson.ObjectId `bson:"_id,omitempty"`
 		Domain     string        `bson:"domain"`
-		Subdomains float64       `bson:"subdomains"`
-		Visited    float64       `bson:"visited"`
+		Subdomains int64         `bson:"subdomains"`
+		Visited    int64         `bson:"visited"`
 	}
 )

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -79,6 +79,9 @@ BlackListed:
     BlackListTable: blacklisted
     Database: rita-blacklist
 
+Dns:
+    ExplodedDnsTable: explodedDns
+
 Crossref:
     InternalTable: internXREF
     ExternalTable: externXREF

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -242,17 +242,17 @@ func (d *docParser) parseLine() {
 			case STRING_SET:
 				tokens := strings.Split(line[idx], ",")
 				tVal := reflect.ValueOf(tokens)
-				data.Field(d.SFields[val]).Set(tVal)
+				data.Field(fieldOffset).Set(tVal)
 				break
 			case ENUM_SET:
 				tokens := strings.Split(line[idx], ",")
 				tVal := reflect.ValueOf(tokens)
-				data.Field(d.SFields[val]).Set(tVal)
+				data.Field(fieldOffset).Set(tVal)
 				break
 			case STRING_VECTOR:
 				tokens := strings.Split(line[idx], ",")
 				tVal := reflect.ValueOf(tokens)
-				data.Field(d.SFields[val]).Set(tVal)
+				data.Field(fieldOffset).Set(tVal)
 				break
 			//case DURATION_VECTOR:
 			//	data.Field(d.SFields[val]).SetString(line[idx])
@@ -268,12 +268,11 @@ func (d *docParser) parseLine() {
 							"error": err.Error(),
 							"value": val,
 						}).Error("Couldn't convert float")
-						data.Field(d.SFields[val]).SetFloat(-1.0)
 						break
 					}
 				}
 				fVal := reflect.ValueOf(floats)
-				data.Field(d.SFields[val]).Set(fVal)
+				data.Field(fieldOffset).Set(fVal)
 				break
 			default:
 				d.log.WithFields(log.Fields{


### PR DESCRIPTION
Implements the analysis described on issue #24. 
We blow apart a FQDN such as imap.google.com into three strings:
```
imap.google.com
google.com
com
```
For each of these strings we calculate how many times each one was looked up and how many unique subdomains exist for each domain (including 1 for the endpoint representing the string itself).

So, if I looked up imap.google.com x 2, calendar.google.com, yahoo.com, and calendar.yahoo.com, Rita would produce:
NOTE: visited is technically incorrect, it is an over estimate because if someone visits imap.google.com, they may not have visited google.com. However, it provides a decent heuristic. A new name should be developed. 
```
imap.google.com subdomains: 1 (itself) visited: 2
calendar.google.com subdomains: 1 (itself) visited: 1
google.com subdomains: 3 (2 + itself) visited: 4
calendar.yahoo.com subdomains: 1 (itself) visited: 1
yahoo.com subdomains: 2 (1 + itself) visited: 2
com subdomains: 6 (5 + itself) visited: 7
