### PR TITLE
Fix error in using bowley skew with very low dispersion

### DIFF
--- a/analysis/beacon/beacon.go
+++ b/analysis/beacon/beacon.go
@@ -248,8 +248,9 @@ func (t *Beacon) analyze() {
 		bNum := low + high - 2*mid
 		bDen := high - low
 
-		//bSkew should equal zero if hte denominator equals zero
-		if bDen != 0 {
+		//bSkew should equal zero if the denominator equals zero
+		//bowley skew is unreliable if Q2 = Q1 or Q2 = Q3
+		if bDen != 0 && mid != low && mid != high {
 			bSkew = float64(bNum) / float64(bDen)
 		}
 


### PR DESCRIPTION
An issue occurred when using Bowley skew with very low dispersion. If Q2 == Q1 or Q2 == Q3, bowley skew responds violently, returning a full 1 or -1. If the quartiles are that close, then we have a very, very large spike in the delta times which skews the histogram as whole, but should not be considered as the max possible skew. Rather, if we have that large of a spike in the delta time histograms, we should score the connection very high as a beacon.

This fixes an issue when testing against Powershell Empire.