### PR TITLE
Fix various cli bugs. Remove all flag.

### DIFF
--- a/analysis/beacon/beacon.go
+++ b/analysis/beacon/beacon.go
@@ -345,8 +345,11 @@ func createCountMap(data []int64) ([]int64, []int64, int64, int64) {
 	return distinct, counts, mode, max
 }
 
-// GetViewPipeline creates an aggregation for user views since the beacon table
-// stores uconn uid's rather than src, dest pairs
+// GetViewPipeline creates an aggregation for user views since the beacon collection
+// stores uconn uid's rather than src, dest pairs. cuttoff is the lowest overall
+// score to report on. Setting cuttoff to 0 retrieves all the records from the 
+// beaconing collection. Setting cuttoff to 1 will prevent the aggregation from
+// returning any records.
 func getViewPipeline(r *database.Resources, cuttoff float64) []bson.D {
 	return []bson.D{
 		{

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -38,11 +38,6 @@ var (
 		Name:  "human-readable, H",
 		Usage: "print a report instead of csv",
 	}
-
-	allFlag = cli.BoolFlag{
-		Name:  "all, a",
-		Usage: "print all available records",
-	}
 )
 
 // bootstrapCommands simply adds a given command to the allCommands array

--- a/commands/delete-database.go
+++ b/commands/delete-database.go
@@ -17,9 +17,10 @@ func init() {
 		Usage: "Delete an imported database",
 		Flags: []cli.Flag{
 			databaseFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}

--- a/commands/import.go
+++ b/commands/import.go
@@ -42,10 +42,10 @@ func doImport(c *cli.Context) error {
 
 	//one flag was set
 	if importDir != "" && databaseName == "" || importDir == "" && databaseName != "" {
-		fmt.Println("Import failed.\nUse 'rita import' to import the directories " +
-			"specified in the config file or 'rita import -i [import-dir] -d [database-name]' " +
-			"to import bro logs from a given directory.")
-		return nil
+		return cli.NewExitError(
+			"Import failed.\nUse 'rita import' to import the directories "+
+				"specified in the config file or 'rita import -i [import-dir] -d [database-name]' "+
+				"to import bro logs from a given directory.", -1)
 	}
 
 	//both flags were set

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -20,7 +20,7 @@ func init() {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 			databaseName := c.String("database")
 			var databases []string
 			if databaseName != "" {

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -42,8 +42,7 @@ func cleanAnalysis(database string, res *database.Resources) error {
 
 	names, err := res.DB.Session.DB(database).CollectionNames()
 	if err != nil || len(names) == 0 {
-		fmt.Fprintf(os.Stderr, "Failed to find analysis results\n")
-		return err
+		return cli.NewExitError("Failed to find analysis results", -1)
 	}
 
 	fmt.Println("Are you sure you want to reset analysis for", database, "[Y/n]")
@@ -81,8 +80,7 @@ func cleanAnalysis(database string, res *database.Resources) error {
 	err3 := res.MetaDB.MarkDBAnalyzed(database, false)
 
 	if err3 != nil {
-		fmt.Fprintf(os.Stderr, "Failed to update metadb\n")
-		return err3
+		return cli.NewExitError("Failed to update metadb", -1)
 	}
 
 	if err == nil && err2Flag == nil && err3 == nil {

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -17,9 +17,10 @@ func init() {
 		Usage: "Reset analysis of one or more databases",
 		Flags: []cli.Flag{
 			databaseFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
@@ -89,4 +90,3 @@ func cleanAnalysis(database string, res *database.Resources) error {
 	}
 	return nil
 }
-

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -21,7 +21,7 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
+			configFlag,
 		},
 		Action: showBeacons,
 	}
@@ -33,17 +33,13 @@ func showBeacons(c *cli.Context) error {
 	if c.String("database") == "" {
 		return cli.NewExitError("Specify a database with -d", -1)
 	}
-	res := database.InitResources("")
+	res := database.InitResources(c.String("config"))
 	res.DB.SelectDB(c.String("database"))
 
 	var data []beaconData.BeaconAnalysisView
-	cutoffScore := .7
-	if c.Bool("all") {
-		cutoffScore = 0
-	}
 
 	ssn := res.DB.Session.Copy()
-	resultsView := beacon.GetBeaconResultsView(res, ssn, cutoffScore)
+	resultsView := beacon.GetBeaconResultsView(res, ssn, 0)
 	if resultsView == nil {
 		return errors.New("No beacons were found for " + c.String("database"))
 	}

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -41,16 +40,23 @@ func showBeacons(c *cli.Context) error {
 	ssn := res.DB.Session.Copy()
 	resultsView := beacon.GetBeaconResultsView(res, ssn, 0)
 	if resultsView == nil {
-		return errors.New("No beacons were found for " + c.String("database"))
+		return cli.NewExitError("No results were found for "+c.String("database"), -1)
 	}
 	resultsView.All(&data)
 	ssn.Close()
 
 	if c.Bool("human-readable") {
-		return showBeaconReport(data)
+		err := showBeaconReport(data)
+		if err != nil {
+			return cli.NewExitError(err.Error(), -1)
+		}
 	}
 
-	return showBeaconCsv(data)
+	err := showBeaconCsv(data)
+	if err != nil {
+		return cli.NewExitError(err.Error(), -1)
+	}
+	return nil
 }
 
 func showBeaconReport(data []beaconData.BeaconAnalysisView) error {

--- a/commands/show-blacklisted.go
+++ b/commands/show-blacklisted.go
@@ -28,6 +28,7 @@ func init() {
 				Usage:       "Show sources with results",
 				Destination: &sourcesFlag,
 			},
+			configFlag,
 		},
 		Action: showBlacklisted,
 	}
@@ -40,7 +41,7 @@ func showBlacklisted(c *cli.Context) error {
 		return cli.NewExitError("Specify a database with -d", -1)
 	}
 
-	res := database.InitResources("")
+	res := database.InitResources(c.String("config"))
 	res.DB.SelectDB(c.String("database"))
 
 	var result blacklistedData.Blacklist

--- a/commands/show-blacklisted.go
+++ b/commands/show-blacklisted.go
@@ -50,6 +50,10 @@ func showBlacklisted(c *cli.Context) error {
 	coll := res.DB.Session.DB(c.String("database")).C(res.System.BlacklistedConfig.BlacklistTable)
 	iter := coll.Find(nil).Sort("-count").Iter()
 
+	if iter.Done() {
+		return cli.NewExitError("No results were found for "+c.String("database"), -1)
+	}
+
 	for iter.Next(&result) {
 		if sourcesFlag {
 			blacklisted.SetBlacklistSources(res, &result)
@@ -58,9 +62,16 @@ func showBlacklisted(c *cli.Context) error {
 	}
 
 	if c.Bool("human-readable") {
-		return showBlacklistedHuman(results)
+		err := showBlacklistedHuman(results)
+		if err != nil {
+			return cli.NewExitError(err.Error(), -1)
+		}
 	}
-	return showBlacklistedCsv(results)
+	err := showBlacklistedCsv(results)
+	if err != nil {
+		return cli.NewExitError(err.Error(), -1)
+	}
+	return nil
 }
 
 // showBlacklisted prints all blacklisted for a given database

--- a/commands/show-databases.go
+++ b/commands/show-databases.go
@@ -12,8 +12,11 @@ func init() {
 	databases := cli.Command{
 		Name:  "show-databases",
 		Usage: "Print the databases currently stored",
+		Flags: []cli.Flag{
+			configFlag,
+		},
 		Action: func(c *cli.Context) error {
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 			for _, name := range res.MetaDB.GetDatabases() {
 				fmt.Println(name)
 			}

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -20,24 +20,19 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var explodedResults []dns.ExplodedDNS
 			iter := res.DB.Session.DB(c.String("database")).C(res.System.DNSConfig.ExplodedDNSTable).Find(nil)
-			count, _ := iter.Count()
 
-			if !c.Bool("all") {
-				count = 15
-			}
-
-			iter.Sort("-subdomains").Limit(count).All(&explodedResults)
+			iter.Sort("-subdomains").All(&explodedResults)
 
 			if c.Bool("human-readable") {
 				return showResultsHuman(explodedResults)

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -20,25 +20,21 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var longConns []data.Conn
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.StructureConfig.ConnTable)
 
 			sortStr := "-duration"
 
-			query := coll.Find(nil).Sort(sortStr)
-			if !c.Bool("all") {
-				query.Limit(15)
-			}
-			query.All(&longConns)
+			coll.Find(nil).Sort(sortStr).All(&longConns)
 
 			if c.Bool("human-readable") {
 				return showConnsHuman(longConns)

--- a/commands/show-scans.go
+++ b/commands/show-scans.go
@@ -21,13 +21,14 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var scans []scanning.Scan
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.ScanningConfig.ScanTable)

--- a/commands/show-scans.go
+++ b/commands/show-scans.go
@@ -34,10 +34,21 @@ func init() {
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.ScanningConfig.ScanTable)
 			coll.Find(nil).All(&scans)
 
-			if c.Bool("human-readable") {
-				return showScansHuman(scans)
+			if len(scans) == 0 {
+				return cli.NewExitError("No results were found for "+c.String("database"), -1)
 			}
-			return showScans(scans)
+
+			if c.Bool("human-readable") {
+				err := showScansHuman(scans)
+				if err != nil {
+					return cli.NewExitError(err.Error(), -1)
+				}
+			}
+			err := showScans(scans)
+			if err != nil {
+				return cli.NewExitError(err.Error(), -1)
+			}
+			return nil
 		},
 	}
 	bootstrapCommands(command)
@@ -51,16 +62,14 @@ func showScans(scans []scanning.Scan) error {
 		return err
 	}
 
-	var error error
 	for _, scan := range scans {
 		sort.Ints(scan.PortSet)
 		err := out.Execute(os.Stdout, scan)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
-			error = err
 		}
 	}
-	return error
+	return nil
 }
 
 // showScans prints all scans for a given database

--- a/commands/show-urls.go
+++ b/commands/show-urls.go
@@ -20,23 +20,19 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var urls []urls.URL
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.UrlsConfig.UrlsTable)
 
-			query := coll.Find(nil).Sort("-length")
-			if !c.Bool("all") {
-				query.Limit(15)
-			}
-			query.All(&urls)
+			coll.Find(nil).Sort("-length").All(&urls)
 
 			if c.Bool("human-readable") {
 				return showURLsHuman(urls)
@@ -51,7 +47,6 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
@@ -63,11 +58,7 @@ func init() {
 			var urls []urls.URL
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.UrlsConfig.UrlsTable)
 
-			query := coll.Find(nil).Sort("-count")
-			if !c.Bool("all") {
-				query.Limit(10)
-			}
-			query.All(&urls)
+			coll.Find(nil).Sort("-count").All(&urls)
 
 			if c.Bool("human-readable") {
 				return showURLsHuman(urls)

--- a/commands/show-urls.go
+++ b/commands/show-urls.go
@@ -34,10 +34,21 @@ func init() {
 
 			coll.Find(nil).Sort("-length").All(&urls)
 
-			if c.Bool("human-readable") {
-				return showURLsHuman(urls)
+			if len(urls) == 0 {
+				return cli.NewExitError("No results were found for "+c.String("database"), -1)
 			}
-			return showURLs(urls)
+
+			if c.Bool("human-readable") {
+				err := showURLsHuman(urls)
+				if err != nil {
+					return cli.NewExitError(err.Error(), -1)
+				}
+			}
+			err := showURLs(urls)
+			if err != nil {
+				return cli.NewExitError(err.Error(), -1)
+			}
+			return nil
 		},
 	}
 	vistedURLs := cli.Command{
@@ -60,10 +71,21 @@ func init() {
 
 			coll.Find(nil).Sort("-count").All(&urls)
 
-			if c.Bool("human-readable") {
-				return showURLsHuman(urls)
+			if len(urls) == 0 {
+				return cli.NewExitError("No results were found for "+c.String("database"), -1)
 			}
-			return showURLs(urls)
+
+			if c.Bool("human-readable") {
+				err := showURLsHuman(urls)
+				if err != nil {
+					return cli.NewExitError(err.Error(), -1)
+				}
+			}
+			err := showURLs(urls)
+			if err != nil {
+				return cli.NewExitError(err.Error(), -1)
+			}
+			return nil
 		},
 	}
 	bootstrapCommands(longURLs, vistedURLs)
@@ -77,15 +99,13 @@ func showURLs(urls []urls.URL) error {
 		return err
 	}
 
-	var error error
 	for _, url := range urls {
 		err := out.Execute(os.Stdout, url)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
-			error = err
 		}
 	}
-	return error
+	return nil
 }
 
 func showURLsHuman(urls []urls.URL) error {

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -45,10 +45,21 @@ func init() {
 
 			coll.Find(nil).Sort(sortStr).All(&agents)
 
-			if c.Bool("human-readable") {
-				return showAgentsHuman(agents)
+			if len(agents) == 0 {
+				return cli.NewExitError("No results were found for "+c.String("database"), -1)
 			}
-			return showAgents(agents)
+
+			if c.Bool("human-readable") {
+				err := showAgentsHuman(agents)
+				if err != nil {
+					return cli.NewExitError(err.Error(), -1)
+				}
+			}
+			err := showAgents(agents)
+			if err != nil {
+				return cli.NewExitError(err.Error(), -1)
+			}
+			return nil
 		},
 	}
 	bootstrapCommands(command)
@@ -62,15 +73,13 @@ func showAgents(agents []useragent.UserAgent) error {
 		return err
 	}
 
-	var error error
 	for _, agent := range agents {
 		err := out.Execute(os.Stdout, agent)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "ERROR: Template failure: %s\n", err.Error())
-			error = err
 		}
 	}
-	return error
+	return nil
 }
 
 func showAgentsHuman(agents []useragent.UserAgent) error {

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -20,18 +20,18 @@ func init() {
 		Flags: []cli.Flag{
 			humanFlag,
 			databaseFlag,
-			allFlag,
 			cli.BoolFlag{
 				Name:  "least-used, l",
-				Usage: "Print the least used user agent strings",
+				Usage: "Sort the user agents from least used to most used.",
 			},
+			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			if c.String("database") == "" {
 				return cli.NewExitError("Specify a database with -d", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var agents []useragent.UserAgent
 			coll := res.DB.Session.DB(c.String("database")).C(res.System.UserAgentConfig.UserAgentTable)
@@ -43,11 +43,7 @@ func init() {
 				sortStr = "-times_used"
 			}
 
-			query := coll.Find(nil).Sort(sortStr)
-			if !c.Bool("all") {
-				query.Limit(15)
-			}
-			query.All(&agents)
+			coll.Find(nil).Sort(sortStr).All(&agents)
 
 			if c.Bool("human-readable") {
 				return showAgentsHuman(agents)


### PR DESCRIPTION
There isn't an open issue for this PR. However, while working on the new blacklist module, I became rather annoyed with rita's cli. I removed the all flag so it displays all results by default. I figure you can use `head` to limit the output. Then, I made sure the configuration file flag was actually being used on all of the commands. Finally, I fixed some errors that were being swallowed, and added some better error reporting. For instance if you issue a show command with an invalid database, it will respond with `No results were found for (database).`