### PR TITLE
Fix parse indexes

### DIFF
--- a/analysis/structure/uconn.go
+++ b/analysis/structure/uconn.go
@@ -112,7 +112,6 @@ func getUniqueConnectionsScript(sysCfg *config.SystemConfig) (string, string, []
 				{"total_bytes", 1},
 				{"avg_bytes", 1},
 				{"total_duration", 1},
-				{"uid", 1},
 			}},
 		},
 		{

--- a/analysis/urls/url.go
+++ b/analysis/urls/url.go
@@ -50,7 +50,6 @@ func getURLCollectionScript(sysCfg *config.SystemConfig) (string, string, []stri
 					var result = {
 						host: this.host,
 						uri: this.uri,
-						uid: this.uid,
 						ip: this.id_resp_h,
 						length: new NumberLong(this.host.length+this.uri.length)
 					};
@@ -70,7 +69,6 @@ func getURLCollectionScript(sysCfg *config.SystemConfig) (string, string, []stri
 				{"uri", "$value.uri"},
 				{"ip", "$value.ip"},
 				{"length", "$value.length"},
-				{"uid", "$value.uid"},
 			}},
 		},
 		{

--- a/parser/parsetypes/conn.go
+++ b/parser/parsetypes/conn.go
@@ -63,7 +63,7 @@ func (in *Conn) TargetCollection(config *config.StructureCfg) string {
 
 //Indices gives MongoDB indices that should be used with the collection
 func (in *Conn) Indices() []string {
-	return []string{"$hashed:id_origin_h", "$hashed:id_resp_h", "$hashed:uid", "-duration", "ts"}
+	return []string{"$hashed:id_origin_h", "$hashed:id_resp_h", "-duration", "ts"}
 }
 
 //Normalize pre processes this type of entry before it is imported by rita

--- a/parser/parsetypes/dns.go
+++ b/parser/parsetypes/dns.go
@@ -68,7 +68,7 @@ func (in *DNS) TargetCollection(config *config.StructureCfg) string {
 
 //Indices gives MongoDB indices that should be used with the collection
 func (in *DNS) Indices() []string {
-	return []string{"$hashed:uid"}
+	return []string{"$hashed:id_origin_h", "$hashed:id_resp_h", "$hashed:query"}
 }
 
 //Normalize pre processes this type of entry before it is imported by rita

--- a/parser/parsetypes/http.go
+++ b/parser/parsetypes/http.go
@@ -84,7 +84,7 @@ func (line *HTTP) TargetCollection(config *config.StructureCfg) string {
 
 //Indices gives MongoDB indices that should be used with the collection
 func (line *HTTP) Indices() []string {
-	return []string{"$hashed:uid"}
+	return []string{"$hashed:id_origin_h", "$hashed:id_resp_h", "$hashed:user_agent"}
 }
 
 // Normalize fixes up absolute uri's as read by bro to be relative


### PR DESCRIPTION
The indexes on the import collections were not being used, and some collections needed indexes that were not there. Standardized indexes on id_origin_h, id_resp_h across all logs. Added user_agent index to http such that the sources for user agents can be found.