### PR TITLE
Apply TLS to MongoDB Connection Fixes #105

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type (
 	//SystemConfig is the container for other config sections
 	SystemConfig struct {
 		BatchSize         int            `yaml:"BatchSize"`
-		DatabaseHost      string         `yaml:"DatabaseHost"`
+		MongoDBConfig     MongoDBCfg     `yaml:"MongoDB"`
 		Prefetch          float64        `yaml:"Prefetch"`
 		LogConfig         LogCfg         `yaml:"LogConfig"`
 		BlacklistedConfig BlacklistedCfg `yaml:"BlackListed"`
@@ -31,6 +31,19 @@ type (
 		BroConfig         BroCfg         `yaml:"Bro"`
 		MetaTables        MetaCfg        `yaml:"MetaTables"`
 		Version           string
+	}
+
+	//MongoDBCfg contains the means for connecting to MongoDB
+	MongoDBCfg struct {
+		ConnectionString string `yaml:"ConnectionString"`
+		AuthMechanism    string `yaml:"AuthenticationMechanism"`
+		TLS              TLSCfg `yaml:"TLS"`
+	}
+
+	//TLSCfg contains the means for connecting to MongoDB over TLS
+	TLSCfg struct {
+		Enabled bool   `yaml:"Enable"`
+		CAFile  string `yaml:"CAFile"`
 	}
 
 	//LogCfg contains the configuration for logging

--- a/database/resources.go
+++ b/database/resources.go
@@ -102,16 +102,16 @@ func InitResources(cfgPath string) *Resources {
 
 //connectToMongoDB connects to MongoDB possibly with authentication and TLS
 func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session, error) {
-	if conf.TLS.Enabled {
-		authMechanism, err := mgosec.ParseMongoAuthMechanism(conf.AuthMechanism)
-		if err != nil {
-			authMechanism = mgosec.None
-			logger.WithFields(log.Fields{
-				"authMechanism": conf.AuthMechanism,
-			}).Error(err.Error())
-			fmt.Println("[!] Could not parse MongoDB authentication mechanism")
-		}
+	authMechanism, err := mgosec.ParseAuthMechanism(conf.AuthMechanism)
+	if err != nil {
+		authMechanism = mgosec.None
+		logger.WithFields(log.Fields{
+			"authMechanism": conf.AuthMechanism,
+		}).Error(err.Error())
+		fmt.Println("[!] Could not parse MongoDB authentication mechanism")
+	}
 
+	if conf.TLS.Enabled {
 		tlsConf := &tls.Config{}
 		if len(conf.TLS.CAFile) > 0 {
 			pem, err := ioutil.ReadFile(conf.TLS.CAFile)
@@ -127,7 +127,7 @@ func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session
 		}
 		return mgosec.Dial(conf.ConnectionString, authMechanism, tlsConf)
 	}
-	return mgo.Dial(conf.ConnectionString)
+	return mgosec.DialInsecure(conf.ConnectionString, authMechanism)
 }
 
 // initLog creates the logger for logging to stdout and file

--- a/database/resources.go
+++ b/database/resources.go
@@ -102,15 +102,6 @@ func InitResources(cfgPath string) *Resources {
 
 //connectToMongoDB connects to MongoDB possibly with authentication and TLS
 func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session, error) {
-	authMechanism, err := mgosec.ParseAuthMechanism(conf.AuthMechanism)
-	if err != nil {
-		authMechanism = mgosec.None
-		logger.WithFields(log.Fields{
-			"authMechanism": conf.AuthMechanism,
-		}).Error(err.Error())
-		fmt.Println("[!] Could not parse MongoDB authentication mechanism")
-	}
-
 	if conf.TLS.Enabled {
 		tlsConf := &tls.Config{}
 		if len(conf.TLS.CAFile) > 0 {
@@ -125,9 +116,9 @@ func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session
 				tlsConf.RootCAs.AppendCertsFromPEM(pem)
 			}
 		}
-		return mgosec.Dial(conf.ConnectionString, authMechanism, tlsConf)
+		return mgosec.Dial(conf.ConnectionString, conf.AuthMechanismParsed, tlsConf)
 	}
-	return mgosec.DialInsecure(conf.ConnectionString, authMechanism)
+	return mgosec.DialInsecure(conf.ConnectionString, conf.AuthMechanismParsed)
 }
 
 // initLog creates the logger for logging to stdout and file

--- a/database/resources.go
+++ b/database/resources.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,7 +12,8 @@ import (
 
 	mgo "gopkg.in/mgo.v2"
 
-	"github.com/Zalgo2462/mgorus"
+	"github.com/ocmdev/mgorus"
+	"github.com/ocmdev/mgosec"
 	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/util"
 	"github.com/rifflock/lfshook"
@@ -47,7 +50,7 @@ func InitResources(cfgPath string) *Resources {
 	}
 
 	// Jump into the requested database
-	session, err := mgo.Dial(conf.DatabaseHost)
+	session, err := connectToMongoDB(&conf.MongoDBConfig, log)
 	if err != nil {
 		fmt.Printf("Failed to connect to database: %s", err.Error())
 		os.Exit(-1)
@@ -67,6 +70,7 @@ func InitResources(cfgPath string) *Resources {
 		lock: new(sync.Mutex),
 	}
 
+	//bundle up the system resources
 	r := &Resources{
 		Log:    log,
 		System: conf,
@@ -84,11 +88,46 @@ func InitResources(cfgPath string) *Resources {
 	if !metaDB.isBuilt() {
 		metaDB.createMetaDB()
 	}
+
+	//Begin logging to the metadatabase
 	if conf.LogConfig.LogToDB {
-		addMongoLogger(log, conf.DatabaseHost, conf.BroConfig.MetaDB,
-			conf.LogConfig.RitaLogTable)
+		log.Hooks.Add(
+			mgorus.NewHookerFromSession(
+				session, conf.BroConfig.MetaDB, conf.LogConfig.RitaLogTable,
+			),
+		)
 	}
 	return r
+}
+
+//connectToMongoDB connects to MongoDB possibly with authentication and TLS
+func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session, error) {
+	if conf.TLS.Enabled {
+		authMechanism, err := mgosec.ParseMongoAuthMechanism(conf.AuthMechanism)
+		if err != nil {
+			authMechanism = mgosec.None
+			logger.WithFields(log.Fields{
+				"authMechanism": conf.AuthMechanism,
+			}).Error(err.Error())
+			fmt.Println("[!] Could not parse MongoDB authentication mechanism")
+		}
+
+		tlsConf := &tls.Config{}
+		if len(conf.TLS.CAFile) > 0 {
+			pem, err := ioutil.ReadFile(conf.TLS.CAFile)
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"CAFile": conf.TLS.CAFile,
+				}).Error(err.Error())
+				fmt.Println("[!] Could not read MongoDB CA file")
+			} else {
+				tlsConf.RootCAs = x509.NewCertPool()
+				tlsConf.RootCAs.AppendCertsFromPEM(pem)
+			}
+		}
+		return mgosec.Dial(conf.ConnectionString, authMechanism, tlsConf)
+	}
+	return mgo.Dial(conf.ConnectionString)
 }
 
 // initLog creates the logger for logging to stdout and file
@@ -136,12 +175,4 @@ func addFileLogger(logger *log.Logger, logPath string) {
 		log.FatalLevel: path.Join(logPath, "fatal.log"),
 		log.PanicLevel: path.Join(logPath, "panic.log"),
 	}))
-}
-
-func addMongoLogger(logger *log.Logger, dbHost, metaDB, logColl string) error {
-	mgoHook, err := mgorus.NewHooker(dbHost, metaDB, logColl)
-	if err == nil {
-		logger.Hooks.Add(mgoHook)
-	}
-	return err
 }

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -1,5 +1,14 @@
-# Mongo Database to connect to
-DatabaseHost: localhost:27017
+MongoDB:
+  # See https://docs.mongodb.com/manual/reference/connection-string/
+  ConnectionString: mongodb://localhost:27017
+  # How to authenticate to MongoDB
+  # Accepted Values: null, "SCRAM-SHA-1", "MONGODB-CR", "PLAIN"
+  AuthenticationMechanism: null
+  # For encrypting data on the wire between RITA and MongoDB
+  TLS:
+    Enable: false
+    #If set, RITA will use the provided CA file instead of the system's CA's
+    CAFile: null
 
 LogConfig:
     # LogLevel


### PR DESCRIPTION
Fixes #105 

In order to configure RITA to  authenticate to a MongoDB server over tls, set up your config like so:
MongoDB:

```
  ConnectionString: mongodb://username:password@some.address:27017
  AuthenticationMechanism: SCRAM-SHA-1
  TLS:
    Enable: true
    CAFile: /path/to/my/private/certificate/authority
```
Of course the CAFile is not required if using a verified certificate.