### PR TITLE
Add Option to Verify TLS Certificate and Split the Config Representation

### DIFF
--- a/analysis/beacon/beacon_test.go
+++ b/analysis/beacon/beacon_test.go
@@ -24,13 +24,13 @@ func printAnalysis(res *datatype_beacon.BeaconAnalysisOutput) string {
 }
 
 func TestAnalysis(t *testing.T) {
-	resources := database.InitMockResources("")
-	resources.Log.Level = log.DebugLevel
-	resources.System.BeaconConfig.DefaultConnectionThresh = 2
+	res := database.InitMockResources("")
+	res.Log.Level = log.DebugLevel
+	res.Config.S.Beacon.DefaultConnectionThresh = 2
 
 	fail := false
 	for i, val := range testDataList {
-		beaconing := newBeacon(resources)
+		beaconing := newBeacon(res)
 		//set first and last connection times
 		beaconing.minTime = val.ts[0]
 		beaconing.maxTime = val.ts[len(val.ts)-1]

--- a/analysis/blacklist/hostnames.go
+++ b/analysis/blacklist/hostnames.go
@@ -29,7 +29,7 @@ func buildBlacklistedHostnames(hostnames *mgo.Iter, res *database.Resources,
 	defer ssn.Close()
 
 	outputCollection := ssn.DB(res.DB.GetSelectedDB()).C(
-		res.System.BlacklistedConfig.HostnamesTable,
+		res.Config.T.Blacklisted.HostnamesTable,
 	)
 	//create type for communicating rita-bl results
 	resultsChannel := make(resultsChan)
@@ -49,8 +49,8 @@ func buildBlacklistedHostnames(hostnames *mgo.Iter, res *database.Resources,
 				err := fillBlacklistedHostname(
 					&blHostname,
 					res.DB.GetSelectedDB(),
-					res.System.DNSConfig.HostnamesTable,
-					res.System.StructureConfig.UniqueConnTable,
+					res.Config.T.DNS.HostnamesTable,
+					res.Config.T.Structure.UniqueConnTable,
 					ssn,
 				)
 				if err != nil {

--- a/analysis/blacklist/ips.go
+++ b/analysis/blacklist/ips.go
@@ -55,11 +55,11 @@ func buildBlacklistedIPs(ips *mgo.Iter, res *database.Resources,
 	var outputCollection *mgo.Collection
 	if source {
 		outputCollection = ssn.DB(res.DB.GetSelectedDB()).C(
-			res.System.BlacklistedConfig.SourceIPsTable,
+			res.Config.T.Blacklisted.SourceIPsTable,
 		)
 	} else {
 		outputCollection = ssn.DB(res.DB.GetSelectedDB()).C(
-			res.System.BlacklistedConfig.DestIPsTable,
+			res.Config.T.Blacklisted.DestIPsTable,
 		)
 	}
 
@@ -82,7 +82,7 @@ func buildBlacklistedIPs(ips *mgo.Iter, res *database.Resources,
 				err := fillBlacklistedIP(
 					&blIP,
 					res.DB.GetSelectedDB(),
-					res.System.StructureConfig.UniqueConnTable,
+					res.Config.T.Structure.UniqueConnTable,
 					ssn,
 					source,
 				)

--- a/analysis/blacklist/urls.go
+++ b/analysis/blacklist/urls.go
@@ -32,7 +32,7 @@ func buildBlacklistedURLs(urls *mgo.Iter, res *database.Resources,
 	defer ssn.Close()
 
 	outputCollection := ssn.DB(res.DB.GetSelectedDB()).C(
-		res.System.BlacklistedConfig.UrlsTable,
+		res.Config.T.Blacklisted.UrlsTable,
 	)
 	//create type for communicating rita-bl results
 	resultsChannel := make(resultsChan)
@@ -53,8 +53,8 @@ func buildBlacklistedURLs(urls *mgo.Iter, res *database.Resources,
 					&blURL,
 					url,
 					res.DB.GetSelectedDB(),
-					res.System.UrlsConfig.UrlsTable,
-					res.System.StructureConfig.UniqueConnTable,
+					res.Config.T.Urls.UrlsTable,
+					res.Config.T.Structure.UniqueConnTable,
 					ssn,
 					prefix,
 				)

--- a/analysis/crossref/beaconing.go
+++ b/analysis/crossref/beaconing.go
@@ -25,7 +25,7 @@ func (s BeaconingSelector) Select(res *database.Resources) (<-chan string, <-cha
 	go func() {
 		ssn := res.DB.Session.Copy()
 		defer ssn.Close()
-		iter := beacon.GetBeaconResultsView(res, ssn, res.System.CrossrefConfig.BeaconThreshold)
+		iter := beacon.GetBeaconResultsView(res, ssn, res.Config.S.Crossref.BeaconThreshold)
 
 		//this will produce duplicates if multiple sources beaconed to the same dest
 		//however, this is accounted for in the finalizing step of xref

--- a/analysis/crossref/blacklist-dest-ips.go
+++ b/analysis/crossref/blacklist-dest-ips.go
@@ -29,13 +29,13 @@ func (s BLDestIPSelector) Select(res *database.Resources) (<-chan string, <-chan
 
 		var blIPs []blacklist.BlacklistedIP
 		ssn.DB(res.DB.GetSelectedDB()).
-			C(res.System.BlacklistedConfig.DestIPsTable).
+			C(res.Config.T.Blacklisted.DestIPsTable).
 			Find(nil).All(&blIPs)
 
 		for _, ip := range blIPs {
 			var connected []structure.UniqueConnection
 			ssn.DB(res.DB.GetSelectedDB()).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"dst": ip.IP},
 			).All(&connected)
 			for _, uconn := range connected {

--- a/analysis/crossref/blacklist-source-ips.go
+++ b/analysis/crossref/blacklist-source-ips.go
@@ -29,13 +29,13 @@ func (s BLSourceIPSelector) Select(res *database.Resources) (<-chan string, <-ch
 
 		var blIPs []blacklist.BlacklistedIP
 		ssn.DB(res.DB.GetSelectedDB()).
-			C(res.System.BlacklistedConfig.SourceIPsTable).
+			C(res.Config.T.Blacklisted.SourceIPsTable).
 			Find(nil).All(&blIPs)
 
 		for _, ip := range blIPs {
 			var connected []structure.UniqueConnection
 			ssn.DB(res.DB.GetSelectedDB()).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"src": ip.IP},
 			).All(&connected)
 			for _, uconn := range connected {

--- a/analysis/crossref/crossref.go
+++ b/analysis/crossref/crossref.go
@@ -23,8 +23,8 @@ func getXRefSelectors() []dataXRef.XRefSelector {
 // BuildXRefCollection runs threaded crossref analysis
 func BuildXRefCollection(res *database.Resources) {
 	indexes := []mgo.Index{{Key: []string{"host"}, Unique: true}}
-	res.DB.CreateCollection(res.System.CrossrefConfig.SourceTable, false, indexes)
-	res.DB.CreateCollection(res.System.CrossrefConfig.DestTable, false, indexes)
+	res.DB.CreateCollection(res.Config.T.Crossref.SourceTable, false, indexes)
+	res.DB.CreateCollection(res.Config.T.Crossref.DestTable, false, indexes)
 
 	//maps from analysis types to channels of hosts found
 	sources := make(map[string]<-chan string)
@@ -40,13 +40,13 @@ func BuildXRefCollection(res *database.Resources) {
 	xRefWG := new(sync.WaitGroup)
 	xRefWG.Add(2)
 	//kick off writes
-	go multiplexXRef(res, res.System.CrossrefConfig.SourceTable, sources, xRefWG)
-	go multiplexXRef(res, res.System.CrossrefConfig.DestTable, destinations, xRefWG)
+	go multiplexXRef(res, res.Config.T.Crossref.SourceTable, sources, xRefWG)
+	go multiplexXRef(res, res.Config.T.Crossref.DestTable, destinations, xRefWG)
 	xRefWG.Wait()
 
 	//group by host ip and put module findings into an array
-	finalizeXRef(res, res.System.CrossrefConfig.SourceTable)
-	finalizeXRef(res, res.System.CrossrefConfig.DestTable)
+	finalizeXRef(res, res.Config.T.Crossref.SourceTable)
+	finalizeXRef(res, res.Config.T.Crossref.DestTable)
 }
 
 //multiplexXRef takes a target colllection, and a map from

--- a/analysis/crossref/scanning.go
+++ b/analysis/crossref/scanning.go
@@ -25,7 +25,7 @@ func (s ScanningSelector) Select(res *database.Resources) (<-chan string, <-chan
 		ssn := res.DB.Session.Copy()
 		defer ssn.Close()
 		iter := ssn.DB(res.DB.GetSelectedDB()).
-			C(res.System.ScanningConfig.ScanTable).Find(nil).Iter()
+			C(res.Config.T.Scanning.ScanTable).Find(nil).Iter()
 
 		var data scanning.Scan
 		for iter.Next(&data) {

--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -25,7 +25,7 @@ func BuildExplodedDNSCollection(res *database.Resources) {
 // times each super domain was visited
 func buildExplodedDNSVistedCounts(res *database.Resources) {
 	res.DB.MapReduceCollection(
-		res.System.StructureConfig.DNSTable,
+		res.Config.T.Structure.DNSTable,
 		mgo.MapReduce{
 			Map:      getExplodedDNSMapper("query"),
 			Reduce:   getExplodedDNSReducer(),
@@ -56,7 +56,7 @@ func zipExplodedDNSResults(res *database.Resources) {
 		{Key: []string{"domain"}, Unique: true},
 		{Key: []string{"subdomains"}},
 	}
-	res.DB.CreateCollection(res.System.DNSConfig.ExplodedDNSTable, false, indexes)
+	res.DB.CreateCollection(res.Config.T.DNS.ExplodedDNSTable, false, indexes)
 	res.DB.AggregateCollection(tempVistedCountCollName, ssn,
 		// nolint: vet
 		[]bson.D{
@@ -80,7 +80,7 @@ func zipExplodedDNSResults(res *database.Resources) {
 				}},
 			},
 			{
-				{"$out", res.System.DNSConfig.ExplodedDNSTable},
+				{"$out", res.Config.T.DNS.ExplodedDNSTable},
 			},
 		},
 	)

--- a/analysis/dns/hostnames.go
+++ b/analysis/dns/hostnames.go
@@ -16,9 +16,9 @@ const tempHostnamesCollName string = "__temp_hostnames"
 func BuildHostnamesCollection(res *database.Resources) {
 	sourceCollectionName,
 		tempCollectionName,
-		pipeline := getHostnamesAggregationScript(res.System)
+		pipeline := getHostnamesAggregationScript(res.Config)
 
-	hostNamesCollection := res.System.DNSConfig.HostnamesTable
+	hostNamesCollection := res.Config.T.DNS.HostnamesTable
 	ssn := res.DB.Session.Copy()
 	defer ssn.Close()
 
@@ -39,8 +39,8 @@ func BuildHostnamesCollection(res *database.Resources) {
 
 //getHostnamesAggregationScript maps dns a type queries to their answers
 //unfortunately, answers may be other hostnames
-func getHostnamesAggregationScript(sysCfg *config.SystemConfig) (string, string, []bson.D) {
-	sourceCollectionName := sysCfg.StructureConfig.DNSTable
+func getHostnamesAggregationScript(conf *config.Config) (string, string, []bson.D) {
+	sourceCollectionName := conf.T.Structure.DNSTable
 
 	newCollectionName := tempHostnamesCollName
 
@@ -118,7 +118,7 @@ func GetIPsFromHost(res *database.Resources, host string) []string {
 	ssn := res.DB.Session.Copy()
 	defer ssn.Close()
 
-	hostnames := ssn.DB(res.DB.GetSelectedDB()).C(res.System.DNSConfig.HostnamesTable)
+	hostnames := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.DNS.HostnamesTable)
 
 	var destIPs dnsTypes.Hostname
 	hostnames.Find(bson.M{"host": host}).One(&destIPs)

--- a/analysis/scanning/scan.go
+++ b/analysis/scanning/scan.go
@@ -14,7 +14,7 @@ func BuildScanningCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipeline := getScanningCollectionScript(res.System)
+		pipeline := getScanningCollectionScript(res.Config)
 
 	// Create it
 	err := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
@@ -28,15 +28,15 @@ func BuildScanningCollection(res *database.Resources) {
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
 }
 
-func getScanningCollectionScript(sysCfg *config.SystemConfig) (string, string, []mgo.Index, []bson.D) {
+func getScanningCollectionScript(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
-	sourceCollectionName := sysCfg.StructureConfig.ConnTable
+	sourceCollectionName := conf.T.Structure.ConnTable
 
 	// Name of the new collection
-	newCollectionName := sysCfg.ScanningConfig.ScanTable
+	newCollectionName := conf.T.Scanning.ScanTable
 
 	// Get scan threshold
-	scanThresh := sysCfg.ScanningConfig.ScanThreshold
+	scanThresh := conf.S.Scanning.ScanThreshold
 
 	// Desired indeces
 	keys := []mgo.Index{

--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -14,7 +14,7 @@ func BuildHostsCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipeline := getHosts(res.System)
+		pipeline := getHosts(res.Config)
 
 	// Aggregate it!
 	errorCheck := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
@@ -29,12 +29,12 @@ func BuildHostsCollection(res *database.Resources) {
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
 }
 
-func getHosts(sysCfg *config.SystemConfig) (string, string, []mgo.Index, []bson.D) {
+func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
-	sourceCollectionName := sysCfg.StructureConfig.ConnTable
+	sourceCollectionName := conf.T.Structure.ConnTable
 
 	// Name of the new collection
-	newCollectionName := sysCfg.StructureConfig.HostTable
+	newCollectionName := conf.T.Structure.HostTable
 
 	// Desired indeces
 	keys := []mgo.Index{

--- a/analysis/structure/uconn.go
+++ b/analysis/structure/uconn.go
@@ -14,7 +14,7 @@ func GetConnSourcesFromDest(res *database.Resources, ip string) []string {
 	ssn := res.DB.Session.Copy()
 	defer ssn.Close()
 
-	cons := ssn.DB(res.DB.GetSelectedDB()).C(res.System.StructureConfig.UniqueConnTable)
+	cons := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.Structure.UniqueConnTable)
 	srcIter := cons.Find(bson.M{"dst": ip}).Iter()
 
 	var srcStruct struct {
@@ -35,7 +35,7 @@ func BuildUniqueConnectionsCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipeline := getUniqueConnectionsScript(res.System)
+		pipeline := getUniqueConnectionsScript(res.Config)
 
 	err := res.DB.CreateCollection(newCollectionName, true, newCollectionKeys)
 	if err != nil {
@@ -49,12 +49,12 @@ func BuildUniqueConnectionsCollection(res *database.Resources) {
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
 }
 
-func getUniqueConnectionsScript(sysCfg *config.SystemConfig) (string, string, []mgo.Index, []bson.D) {
+func getUniqueConnectionsScript(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
-	sourceCollectionName := sysCfg.StructureConfig.ConnTable
+	sourceCollectionName := conf.T.Structure.ConnTable
 
 	// Name of the new collection
-	newCollectionName := sysCfg.StructureConfig.UniqueConnTable
+	newCollectionName := conf.T.Structure.UniqueConnTable
 
 	// Desired Indeces
 	keys := []mgo.Index{

--- a/analysis/urls/url.go
+++ b/analysis/urls/url.go
@@ -15,7 +15,7 @@ func BuildUrlsCollection(res *database.Resources) {
 		newCollectionName,
 		newCollectionKeys,
 		job,
-		pipeline := getURLCollectionScript(res.System)
+		pipeline := getURLCollectionScript(res.Config)
 
 	// Create it
 	err := res.DB.CreateCollection(newCollectionName, false, []mgo.Index{})
@@ -34,17 +34,17 @@ func BuildUrlsCollection(res *database.Resources) {
 	// Aggregate it
 	res.DB.AggregateCollection(newCollectionName, ssn, pipeline)
 	for _, index := range newCollectionKeys {
-		ssn.DB(res.DB.GetSelectedDB()).C(res.System.UrlsConfig.UrlsTable).
+		ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.Urls.UrlsTable).
 			EnsureIndex(index)
 	}
 }
 
-func getURLCollectionScript(sysCfg *config.SystemConfig) (string, string, []mgo.Index, mgo.MapReduce, []bson.D) {
+func getURLCollectionScript(conf *config.Config) (string, string, []mgo.Index, mgo.MapReduce, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
-	sourceCollectionName := sysCfg.StructureConfig.HTTPTable
+	sourceCollectionName := conf.T.Structure.HTTPTable
 
 	// Name of the new collection
-	newCollectionName := sysCfg.UrlsConfig.UrlsTable
+	newCollectionName := conf.T.Urls.UrlsTable
 
 	// Desired indeces
 	keys := []mgo.Index{

--- a/analysis/useragent/useragent.go
+++ b/analysis/useragent/useragent.go
@@ -14,7 +14,7 @@ func BuildUserAgentCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipeline := getUserAgentCollectionScript(res.System)
+		pipeline := getUserAgentCollectionScript(res.Config)
 
 	// Create it
 	err := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
@@ -30,12 +30,12 @@ func BuildUserAgentCollection(res *database.Resources) {
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
 }
 
-func getUserAgentCollectionScript(sysCfg *config.SystemConfig) (string, string, []mgo.Index, []bson.D) {
+func getUserAgentCollectionScript(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
-	sourceCollectionName := sysCfg.StructureConfig.HTTPTable
+	sourceCollectionName := conf.T.Structure.HTTPTable
 
 	// Name of the new collection
-	newCollectionName := sysCfg.UserAgentConfig.UserAgentTable
+	newCollectionName := conf.T.UserAgent.UserAgentTable
 
 	// Desired indeces
 	keys := []mgo.Index{

--- a/commands/import.go
+++ b/commands/import.go
@@ -50,19 +50,19 @@ func doImport(c *cli.Context) error {
 
 	//both flags were set
 	if importDir != "" && databaseName != "" {
-		res.System.BroConfig.LogPath = importDir
-		res.System.BroConfig.DBPrefix = ""
+		res.Config.S.Bro.LogPath = importDir
+		res.Config.S.Bro.DBPrefix = ""
 		//Clear out the directory map and set the default database
-		res.System.BroConfig.DirectoryMap = make(map[string]string)
-		res.System.BroConfig.DefaultDatabase = databaseName
+		res.Config.S.Bro.DirectoryMap = make(map[string]string)
+		res.Config.S.Bro.DefaultDatabase = databaseName
 	}
 
-	res.Log.Infof("Importing %s\n", res.System.BroConfig.LogPath)
-	fmt.Println("[+] Importing " + res.System.BroConfig.LogPath)
+	res.Log.Infof("Importing %s\n", res.Config.S.Bro.LogPath)
+	fmt.Println("[+] Importing " + res.Config.S.Bro.LogPath)
 	importer := parser.NewFSImporter(res, threads, threads)
 	datastore := parser.NewMongoDatastore(res.DB.Session, res.MetaDB,
-		res.System.BroConfig.ImportBuffer, res.Log)
+		res.Config.S.Bro.ImportBuffer, res.Log)
 	importer.Run(datastore)
-	res.Log.Infof("Finished importing %s\n", res.System.BroConfig.LogPath)
+	res.Log.Infof("Finished importing %s\n", res.Config.S.Bro.LogPath)
 	return nil
 }

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -36,9 +36,9 @@ func init() {
 func cleanAnalysis(database string, res *database.Resources) error {
 	//clean database
 
-	conn := res.System.StructureConfig.ConnTable
-	http := res.System.StructureConfig.HTTPTable
-	dns := res.System.StructureConfig.DNSTable
+	conn := res.Config.T.Structure.ConnTable
+	http := res.Config.T.Structure.HTTPTable
+	dns := res.Config.T.Structure.DNSTable
 
 	names, err := res.DB.Session.DB(database).CollectionNames()
 	if err != nil || len(names) == 0 {

--- a/commands/show-bl-hostname.go
+++ b/commands/show-bl-hostname.go
@@ -45,7 +45,7 @@ func printBLHostnames(c *cli.Context) error {
 
 	var blHosts []blacklist.BlacklistedHostname
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.HostnamesTable).
+		C(res.Config.T.Blacklisted.HostnamesTable).
 		Find(nil).Sort("-" + sort).All(&blHosts)
 
 	if len(blHosts) == 0 {
@@ -62,7 +62,7 @@ func printBLHostnames(c *cli.Context) error {
 				//then find all of the hosts which talked to the ip
 				var connected []structure.UniqueConnection
 				res.DB.Session.DB(db).
-					C(res.System.StructureConfig.UniqueConnTable).Find(
+					C(res.Config.T.Structure.UniqueConnTable).Find(
 					bson.M{"dst": ip},
 				).All(&connected)
 				//and aggregate the source ip addresses

--- a/commands/show-bl-ip.go
+++ b/commands/show-bl-ip.go
@@ -72,7 +72,7 @@ func printBLSourceIPs(c *cli.Context) error {
 
 	var blIPs []blacklist.BlacklistedIP
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.SourceIPsTable).
+		C(res.Config.T.Blacklisted.SourceIPsTable).
 		Find(nil).Sort("-" + sort).All(&blIPs)
 
 	if len(blIPs) == 0 {
@@ -83,7 +83,7 @@ func printBLSourceIPs(c *cli.Context) error {
 		for i, ip := range blIPs {
 			var connected []structure.UniqueConnection
 			res.DB.Session.DB(db).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"src": ip.IP},
 			).All(&connected)
 			for _, uconn := range connected {
@@ -115,7 +115,7 @@ func printBLDestIPs(c *cli.Context) error {
 
 	var blIPs []blacklist.BlacklistedIP
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.DestIPsTable).
+		C(res.Config.T.Blacklisted.DestIPsTable).
 		Find(nil).Sort("-" + sort).All(&blIPs)
 
 	if len(blIPs) == 0 {
@@ -126,7 +126,7 @@ func printBLDestIPs(c *cli.Context) error {
 		for i, ip := range blIPs {
 			var connected []structure.UniqueConnection
 			res.DB.Session.DB(db).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"dst": ip.IP},
 			).All(&connected)
 			for _, uconn := range connected {

--- a/commands/show-bl-url.go
+++ b/commands/show-bl-url.go
@@ -43,7 +43,7 @@ func printBLURLs(c *cli.Context) error {
 
 	var blURLs []blacklist.BlacklistedURL
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.UrlsTable).
+		C(res.Config.T.Blacklisted.UrlsTable).
 		Find(nil).Sort("-" + sort).All(&blURLs)
 
 	if len(blURLs) == 0 {
@@ -55,7 +55,7 @@ func printBLURLs(c *cli.Context) error {
 		for i, blURL := range blURLs {
 			//get the ips associated with the url
 			var urlEntry urls.URL
-			res.DB.Session.DB(db).C(res.System.UrlsConfig.UrlsTable).
+			res.DB.Session.DB(db).C(res.Config.T.Urls.UrlsTable).
 				Find(bson.M{"url": blURL.Host, "uri": blURL.Resource}).One(&urlEntry)
 			ips := urlEntry.IPs
 			//and loop over the ips
@@ -63,7 +63,7 @@ func printBLURLs(c *cli.Context) error {
 				//then find all of the hosts which talked to the ip
 				var connected []structure.UniqueConnection
 				res.DB.Session.DB(db).
-					C(res.System.StructureConfig.UniqueConnTable).Find(
+					C(res.Config.T.Structure.UniqueConnTable).Find(
 					bson.M{"dst": ip},
 				).All(&connected)
 				//and aggregate the source ip addresses

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -30,7 +30,7 @@ func init() {
 			res := database.InitResources(c.String("config"))
 
 			var explodedResults []dns.ExplodedDNS
-			iter := res.DB.Session.DB(c.String("database")).C(res.System.DNSConfig.ExplodedDNSTable).Find(nil)
+			iter := res.DB.Session.DB(c.String("database")).C(res.Config.T.DNS.ExplodedDNSTable).Find(nil)
 
 			iter.Sort("-subdomains").All(&explodedResults)
 

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -30,7 +30,7 @@ func init() {
 			res := database.InitResources(c.String("config"))
 
 			var longConns []data.Conn
-			coll := res.DB.Session.DB(c.String("database")).C(res.System.StructureConfig.ConnTable)
+			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Structure.ConnTable)
 
 			sortStr := "-duration"
 

--- a/commands/show-scans.go
+++ b/commands/show-scans.go
@@ -31,7 +31,7 @@ func init() {
 			res := database.InitResources(c.String("config"))
 
 			var scans []scanning.Scan
-			coll := res.DB.Session.DB(c.String("database")).C(res.System.ScanningConfig.ScanTable)
+			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Scanning.ScanTable)
 			coll.Find(nil).All(&scans)
 
 			if len(scans) == 0 {

--- a/commands/show-urls.go
+++ b/commands/show-urls.go
@@ -30,7 +30,7 @@ func init() {
 			res := database.InitResources(c.String("config"))
 
 			var urls []urls.URL
-			coll := res.DB.Session.DB(c.String("database")).C(res.System.UrlsConfig.UrlsTable)
+			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Urls.UrlsTable)
 
 			coll.Find(nil).Sort("-length").All(&urls)
 
@@ -67,7 +67,7 @@ func init() {
 			res := database.InitResources("")
 
 			var urls []urls.URL
-			coll := res.DB.Session.DB(c.String("database")).C(res.System.UrlsConfig.UrlsTable)
+			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Urls.UrlsTable)
 
 			coll.Find(nil).Sort("-count").All(&urls)
 

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -34,7 +34,7 @@ func init() {
 			res := database.InitResources(c.String("config"))
 
 			var agents []useragent.UserAgent
-			coll := res.DB.Session.DB(c.String("database")).C(res.System.UserAgentConfig.UserAgentTable)
+			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.UserAgent.UserAgentTable)
 
 			var sortStr string
 			if c.Bool("least-used") {

--- a/commands/test-config.go
+++ b/commands/test-config.go
@@ -30,11 +30,18 @@ func init() {
 func testConfiguration(c *cli.Context) error {
 	res := database.InitResources(c.String("config"))
 
-	yml, err := yaml.Marshal(res.System)
+	staticConfig, err := yaml.Marshal(res.Config.S)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "\n%s\n", string(yml))
+	tableConfig, err := yaml.Marshal(res.Config.T)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "\n%s\n", string(staticConfig))
+	fmt.Fprintf(os.Stdout, "\n%s\n", string(tableConfig))
+
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,150 +2,25 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"reflect"
-	"time"
-
-	"github.com/ocmdev/mgosec"
-
-	"gopkg.in/yaml.v2"
 )
 
 //VERSION is filled at compile time with the git version of RITA
 var VERSION = "undefined"
 
 type (
-	//SystemConfig is the container for other config sections
-	SystemConfig struct {
-		BatchSize         int            `yaml:"BatchSize"`
-		MongoDBConfig     MongoDBCfg     `yaml:"MongoDB"`
-		Prefetch          float64        `yaml:"Prefetch"`
-		LogConfig         LogCfg         `yaml:"LogConfig"`
-		BlacklistedConfig BlacklistedCfg `yaml:"BlackListed"`
-		DNSConfig         DNSCfg         `yaml:"Dns"`
-		CrossrefConfig    CrossrefCfg    `yaml:"Crossref"`
-		ScanningConfig    ScanningCfg    `yaml:"Scanning"`
-		StructureConfig   StructureCfg   `yaml:"Structure"`
-		BeaconConfig      BeaconCfg      `yaml:"Beacon"`
-		UrlsConfig        UrlsCfg        `yaml:"Urls"`
-		UserAgentConfig   UserAgentCfg   `yaml:"UserAgent"`
-		BroConfig         BroCfg         `yaml:"Bro"`
-		MetaTables        MetaCfg        `yaml:"MetaTables"`
-		Version           string
-	}
-
-	//MongoDBCfg contains the means for connecting to MongoDB
-	MongoDBCfg struct {
-		ConnectionString    string               `yaml:"ConnectionString"`
-		SocketTimeout       time.Duration        `yaml:"SocketTimeout"`
-		AuthMechanism       string               `yaml:"AuthenticationMechanism"`
-		AuthMechanismParsed mgosec.AuthMechanism `yaml:"AuthenticationMechanismParsed,omitempty"`
-		TLS                 TLSCfg               `yaml:"TLS"`
-	}
-
-	//TLSCfg contains the means for connecting to MongoDB over TLS
-	TLSCfg struct {
-		Enabled bool   `yaml:"Enable"`
-		CAFile  string `yaml:"CAFile"`
-	}
-
-	//LogCfg contains the configuration for logging
-	LogCfg struct {
-		LogLevel     int    `yaml:"LogLevel"`
-		RitaLogPath  string `yaml:"RitaLogPath"`
-		LogToFile    bool   `yaml:"LogToFile"`
-		RitaLogTable string `yaml:"RitaLogTable"`
-		LogToDB      bool   `yaml:"LogToDB"`
-	}
-
-	//StructureCfg contains the names of the base level collections
-	StructureCfg struct {
-		ConnTable       string `yaml:"ConnectionTable"`
-		HTTPTable       string `yaml:"HttpTable"`
-		DNSTable        string `yaml:"DnsTable"`
-		UniqueConnTable string `yaml:"UniqueConnectionTable"`
-		HostTable       string `yaml:"HostTable"`
-	}
-
-	//BlacklistedCfg is used to control the blacklisted analysis module
-	BlacklistedCfg struct {
-		BlacklistDatabase  string          `yaml:"Database"`
-		UseIPms            bool            `yaml:"myIP.ms"`
-		UseDNSBH           bool            `yaml:"MalwareDomains.com"`
-		UseMDL             bool            `yaml:"MalwareDomainList.com"`
-		SafeBrowsing       SafeBrowsingCfg `yaml:"SafeBrowsing"`
-		IPBlacklists       []string        `yaml:"CustomIPBlacklists"`
-		HostnameBlacklists []string        `yaml:"CustomHostnameBlacklists"`
-		URLBlacklists      []string        `yaml:"CustomURLBlacklists"`
-		SourceIPsTable     string          `yaml:"SourceIPsTable"`
-		DestIPsTable       string          `yaml:"DestIPsTable"`
-		HostnamesTable     string          `yaml:"HostnamesTable"`
-		UrlsTable          string          `yaml:"UrlsTable"`
-	}
-
-	//DNSCfg is used to control the dns analysis module
-	DNSCfg struct {
-		ExplodedDNSTable string `yaml:"ExplodedDnsTable"`
-		HostnamesTable   string `yaml:"HostnamesTable"`
-	}
-
-	//CrossrefCfg is used to control the crossref analysis module
-	CrossrefCfg struct {
-		SourceTable     string  `yaml:"SourceTable"`
-		DestTable       string  `yaml:"DestinationTable"`
-		BeaconThreshold float64 `yaml:"BeaconThreshold"`
-	}
-
-	//SafeBrowsingCfg contains the details for contacting Google's safebrowsing api
-	SafeBrowsingCfg struct {
-		APIKey   string `yaml:"APIKey"`
-		Database string `yaml:"Database"`
-	}
-
-	//ScanningCfg is used to control the scanning analysis module
-	ScanningCfg struct {
-		ScanThreshold int    `yaml:"ScanThreshold"`
-		ScanTable     string `yaml:"ScanTable"`
-	}
-
-	//BeaconCfg is used to control the beaconing analysis module
-	BeaconCfg struct {
-		DefaultConnectionThresh int    `yaml:"DefaultConnectionThresh"`
-		BeaconTable             string `yaml:"BeaconTable"`
-	}
-
-	//UrlsCfg is used to control the urls analysis module
-	UrlsCfg struct {
-		UrlsTable string `yaml:"UrlsTable"`
-	}
-
-	//UserAgentCfg is used to control the urls analysis module
-	UserAgentCfg struct {
-		UserAgentTable string `yaml:"UserAgentTable"`
-	}
-
-	//BroCfg controls the file parser
-	BroCfg struct {
-		LogPath         string            `yaml:"LogPath"`
-		DBPrefix        string            `yaml:"DBPrefix"`
-		MetaDB          string            `yaml:"MetaDB"`
-		DirectoryMap    map[string]string `yaml:"DirectoryMap"`
-		DefaultDatabase string            `yaml:"DefaultDatabase"`
-		UseDates        bool              `yaml:"UseDates"`
-		ImportBuffer    int               `yaml:"ImportBuffer"`
-	}
-
-	//MetaCfg contains the meta db collection names
-	MetaCfg struct {
-		FilesTable     string `yaml:"FilesTable"`
-		DatabasesTable string `yaml:"DatabasesTable"`
+	//Config holds the configuration for the running system
+	Config struct {
+		R RunningCfg
+		S StaticCfg
+		T TableCfg
 	}
 )
 
 // GetConfig retrieves a configuration in order of precedence
-func GetConfig(cfgPath string) (*SystemConfig, bool) {
+func GetConfig(cfgPath string) (*Config, error) {
 	if cfgPath != "" {
 		return loadSystemConfig(cfgPath)
 	}
@@ -155,11 +30,7 @@ func GetConfig(cfgPath string) (*SystemConfig, bool) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not get user info: %s\n", err.Error())
 	} else {
-
-		conf, ok := loadSystemConfig(user.HomeDir + "/.rita/config.yaml")
-		if ok {
-			return conf, ok
-		}
+		return loadSystemConfig(user.HomeDir + "/.rita/config.yaml")
 	}
 
 	// If none of the other configs have worked, go for the global config
@@ -167,42 +38,27 @@ func GetConfig(cfgPath string) (*SystemConfig, bool) {
 }
 
 // loadSystemConfig attempts to parse a config file
-func loadSystemConfig(cfgPath string) (*SystemConfig, bool) {
-	var config = new(SystemConfig)
-
-	config.Version = VERSION
-
-	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
-		cfgFile, err := ioutil.ReadFile(cfgPath)
-		if err != nil {
-			return config, false
-		}
-		err = yaml.Unmarshal(cfgFile, config)
-
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to read config: %s\n", err.Error())
-			return config, false
-		}
-
-		// expand env variables, config is a pointer
-		// so we have to call elem on the reflect value
-		expandConfig(reflect.ValueOf(config).Elem())
-
-		//parse out the mongo authentication mechanism
-		authMechanism, err := mgosec.ParseAuthMechanism(
-			config.MongoDBConfig.AuthMechanism,
-		)
-		if err != nil {
-			authMechanism = mgosec.None
-			fmt.Println("[!] Could not parse MongoDB authentication mechanism")
-		}
-		config.MongoDBConfig.AuthMechanismParsed = authMechanism
-
-		//set the timeout time in hours
-		config.MongoDBConfig.SocketTimeout *= time.Hour
-		return config, true
+func loadSystemConfig(cfgPath string) (*Config, error) {
+	var config = new(Config)
+	static, err := loadStaticConfig(cfgPath)
+	if err != nil {
+		return config, err
 	}
-	return config, false
+	config.S = *static
+
+	tables, err := loadTableConfig(cfgPath)
+	if err != nil {
+		return config, err
+	}
+	config.T = *tables
+
+	running, err := loadRunningConfig(static)
+	if err != nil {
+		return config, err
+	}
+	config.R = *running
+
+	return config, err
 }
 
 // expandConfig expands environment variables in config strings

--- a/config/running.go
+++ b/config/running.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/ocmdev/mgosec"
+)
+
+type (
+	//RunningCfg holds configuration options that are parsed at run time
+	RunningCfg struct {
+		MongoDB MongoDBRunningCfg
+		Version string
+	}
+
+	//MongoDBRunningCfg holds parsed information for connecting to MongoDB
+	MongoDBRunningCfg struct {
+		AuthMechanismParsed mgosec.AuthMechanism
+		TLS                 struct {
+			TLSConfig *tls.Config
+		}
+	}
+)
+
+// loadRunningConfig attempts deserializes data in the static config
+func loadRunningConfig(config *StaticCfg) (*RunningCfg, error) {
+	var outConfig = new(RunningCfg)
+	var err error
+
+	outConfig.Version = VERSION
+
+	//parse the tls configuration
+	if config.MongoDB.TLS.Enabled {
+		tlsConf := &tls.Config{}
+		if !config.MongoDB.TLS.VerifyCertificate {
+			tlsConf.InsecureSkipVerify = true
+		}
+		if len(config.MongoDB.TLS.CAFile) > 0 {
+			pem, err2 := ioutil.ReadFile(config.MongoDB.TLS.CAFile)
+			err = err2
+			if err != nil {
+				fmt.Println("[!] Could not read MongoDB CA file")
+			} else {
+				tlsConf.RootCAs = x509.NewCertPool()
+				tlsConf.RootCAs.AppendCertsFromPEM(pem)
+			}
+		}
+		outConfig.MongoDB.TLS.TLSConfig = tlsConf
+	}
+
+	//parse out the mongo authentication mechanism
+	authMechanism, err := mgosec.ParseAuthMechanism(
+		config.MongoDB.AuthMechanism,
+	)
+	if err != nil {
+		authMechanism = mgosec.None
+		fmt.Println("[!] Could not parse MongoDB authentication mechanism")
+	}
+	outConfig.MongoDB.AuthMechanismParsed = authMechanism
+
+	return outConfig, err
+}

--- a/config/static.go
+++ b/config/static.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type (
+	//StaticCfg is the container for other static config sections
+	StaticCfg struct {
+		MongoDB     MongoDBStaticCfg     `yaml:"MongoDB"`
+		Log         LogStaticCfg         `yaml:"LogConfig"`
+		Blacklisted BlacklistedStaticCfg `yaml:"BlackListed"`
+		Crossref    CrossrefStaticCfg    `yaml:"Crossref"`
+		Scanning    ScanningStaticCfg    `yaml:"Scanning"`
+		Beacon      BeaconStaticCfg      `yaml:"Beacon"`
+		Bro         BroStaticCfg         `yaml:"Bro"`
+	}
+
+	//MongoDBStaticCfg contains the means for connecting to MongoDB
+	MongoDBStaticCfg struct {
+		ConnectionString string       `yaml:"ConnectionString"`
+		AuthMechanism    string       `yaml:"AuthenticationMechanism"`
+		TLS              TLSStaticCfg `yaml:"TLS"`
+	}
+
+	//TLSStaticCfg contains the means for connecting to MongoDB over TLS
+	TLSStaticCfg struct {
+		Enabled           bool   `yaml:"Enable"`
+		VerifyCertificate bool   `yaml:"VerifyCertificate"`
+		CAFile            string `yaml:"CAFile"`
+	}
+
+	//LogStaticCfg contains the configuration for logging
+	LogStaticCfg struct {
+		LogLevel    int    `yaml:"LogLevel"`
+		RitaLogPath string `yaml:"RitaLogPath"`
+		LogToFile   bool   `yaml:"LogToFile"`
+		LogToDB     bool   `yaml:"LogToDB"`
+	}
+
+	//BlacklistedStaticCfg is used to control the blacklisted analysis module
+	BlacklistedStaticCfg struct {
+		BlacklistDatabase  string                `yaml:"Database"`
+		UseIPms            bool                  `yaml:"myIP.ms"`
+		UseDNSBH           bool                  `yaml:"MalwareDomains.com"`
+		UseMDL             bool                  `yaml:"MalwareDomainList.com"`
+		SafeBrowsing       SafeBrowsingStaticCfg `yaml:"SafeBrowsing"`
+		IPBlacklists       []string              `yaml:"CustomIPBlacklists"`
+		HostnameBlacklists []string              `yaml:"CustomHostnameBlacklists"`
+		URLBlacklists      []string              `yaml:"CustomURLBlacklists"`
+	}
+
+	//CrossrefStaticCfg is used to control the crossref analysis module
+	CrossrefStaticCfg struct {
+		BeaconThreshold float64 `yaml:"BeaconThreshold"`
+	}
+
+	//SafeBrowsingStaticCfg contains the details for contacting Google's safebrowsing api
+	SafeBrowsingStaticCfg struct {
+		APIKey   string `yaml:"APIKey"`
+		Database string `yaml:"Database"`
+	}
+
+	//ScanningStaticCfg is used to control the scanning analysis module
+	ScanningStaticCfg struct {
+		ScanThreshold int `yaml:"ScanThreshold"`
+	}
+
+	//BeaconStaticCfg is used to control the beaconing analysis module
+	BeaconStaticCfg struct {
+		DefaultConnectionThresh int `yaml:"DefaultConnectionThresh"`
+	}
+
+	//BroStaticCfg controls the file parser
+	BroStaticCfg struct {
+		LogPath         string            `yaml:"LogPath"`
+		DBPrefix        string            `yaml:"DBPrefix"`
+		MetaDB          string            `yaml:"MetaDB"`
+		DirectoryMap    map[string]string `yaml:"DirectoryMap"`
+		DefaultDatabase string            `yaml:"DefaultDatabase"`
+		UseDates        bool              `yaml:"UseDates"`
+		ImportBuffer    int               `yaml:"ImportBuffer"`
+	}
+)
+
+// loadStaticConfig attempts to parse a config file
+func loadStaticConfig(cfgPath string) (*StaticCfg, error) {
+	var config = new(StaticCfg)
+	_, err := os.Stat(cfgPath)
+
+	if os.IsNotExist(err) {
+		return config, err
+	}
+
+	cfgFile, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return config, err
+	}
+	err = yaml.Unmarshal(cfgFile, config)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config: %s\n", err.Error())
+		return config, err
+	}
+
+	// expand env variables, config is a pointer
+	// so we have to call elem on the reflect value
+	expandConfig(reflect.ValueOf(config).Elem())
+
+	return config, nil
+}

--- a/config/static.go
+++ b/config/static.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-
+	"time"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -23,9 +23,10 @@ type (
 
 	//MongoDBStaticCfg contains the means for connecting to MongoDB
 	MongoDBStaticCfg struct {
-		ConnectionString string       `yaml:"ConnectionString"`
-		AuthMechanism    string       `yaml:"AuthenticationMechanism"`
-		TLS              TLSStaticCfg `yaml:"TLS"`
+		ConnectionString string        `yaml:"ConnectionString"`
+		AuthMechanism    string        `yaml:"AuthenticationMechanism"`
+		SocketTimeout    time.Duration `yaml:"SocketTimeout"`
+		TLS              TLSStaticCfg  `yaml:"TLS"`
 	}
 
 	//TLSStaticCfg contains the means for connecting to MongoDB over TLS
@@ -111,6 +112,9 @@ func loadStaticConfig(cfgPath string) (*StaticCfg, error) {
 	// expand env variables, config is a pointer
 	// so we have to call elem on the reflect value
 	expandConfig(reflect.ValueOf(config).Elem())
+
+	// set the socket time out in hours
+	config.MongoDB.SocketTimeout *= time.Hour
 
 	return config, nil
 }

--- a/config/tables.go
+++ b/config/tables.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type (
+	//TableCfg is the container for other table config sections
+	TableCfg struct {
+		Log         LogTableCfg         `yaml:"LogConfig"`
+		Blacklisted BlacklistedTableCfg `yaml:"BlackListed"`
+		DNS         DNSTableCfg         `yaml:"Dns"`
+		Crossref    CrossrefTableCfg    `yaml:"Crossref"`
+		Scanning    ScanningTableCfg    `yaml:"Scanning"`
+		Structure   StructureTableCfg   `yaml:"Structure"`
+		Beacon      BeaconTableCfg      `yaml:"Beacon"`
+		Urls        UrlsTableCfg        `yaml:"Urls"`
+		UserAgent   UserAgentTableCfg   `yaml:"UserAgent"`
+		Meta        MetaTableCfg        `yaml:"MetaTables"`
+	}
+
+	//LogTableCfg contains the configuration for logging
+	LogTableCfg struct {
+		RitaLogTable string `yaml:"RitaLogTable"`
+	}
+
+	//StructureTableCfg contains the names of the base level collections
+	StructureTableCfg struct {
+		ConnTable       string `yaml:"ConnectionTable"`
+		HTTPTable       string `yaml:"HttpTable"`
+		DNSTable        string `yaml:"DnsTable"`
+		UniqueConnTable string `yaml:"UniqueConnectionTable"`
+		HostTable       string `yaml:"HostTable"`
+	}
+
+	//BlacklistedTableCfg is used to control the blacklisted analysis module
+	BlacklistedTableCfg struct {
+		BlacklistDatabase string `yaml:"Database"`
+		SourceIPsTable    string `yaml:"SourceIPsTable"`
+		DestIPsTable      string `yaml:"DestIPsTable"`
+		HostnamesTable    string `yaml:"HostnamesTable"`
+		UrlsTable         string `yaml:"UrlsTable"`
+	}
+
+	//DNSTableCfg is used to control the dns analysis module
+	DNSTableCfg struct {
+		ExplodedDNSTable string `yaml:"ExplodedDnsTable"`
+		HostnamesTable   string `yaml:"HostnamesTable"`
+	}
+
+	//CrossrefTableCfg is used to control the crossref analysis module
+	CrossrefTableCfg struct {
+		SourceTable string `yaml:"SourceTable"`
+		DestTable   string `yaml:"DestinationTable"`
+	}
+
+	//ScanningTableCfg is used to control the scanning analysis module
+	ScanningTableCfg struct {
+		ScanTable string `yaml:"ScanTable"`
+	}
+
+	//BeaconTableCfg is used to control the beaconing analysis module
+	BeaconTableCfg struct {
+		BeaconTable string `yaml:"BeaconTable"`
+	}
+
+	//UrlsTableCfg is used to control the urls analysis module
+	UrlsTableCfg struct {
+		UrlsTable string `yaml:"UrlsTable"`
+	}
+
+	//UserAgentTableCfg is used to control the urls analysis module
+	UserAgentTableCfg struct {
+		UserAgentTable string `yaml:"UserAgentTable"`
+	}
+
+	//MetaTableCfg contains the meta db collection names
+	MetaTableCfg struct {
+		FilesTable     string `yaml:"FilesTable"`
+		DatabasesTable string `yaml:"DatabasesTable"`
+	}
+)
+
+// loadTableConfig attempts to parse a config file
+func loadTableConfig(cfgPath string) (*TableCfg, error) {
+	var config = new(TableCfg)
+	_, err := os.Stat(cfgPath)
+
+	if os.IsNotExist(err) {
+		return config, err
+	}
+
+	cfgFile, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return config, err
+	}
+	err = yaml.Unmarshal(cfgFile, config)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config: %s\n", err.Error())
+		return config, err
+	}
+
+	// expand env variables, config is a pointer
+	// so we have to call elem on the reflect value
+	expandConfig(reflect.ValueOf(config).Elem())
+
+	return config, nil
+}

--- a/database/mock.go
+++ b/database/mock.go
@@ -11,14 +11,14 @@ import (
 // returning a *Resources object which has all of the necessary configuration information
 func InitMockResources(cfgPath string) *Resources {
 	//TODO: hard code in a test config
-	conf, ok := config.GetConfig(cfgPath)
-	if !ok {
+	conf, err := config.GetConfig(cfgPath)
+	if err != nil {
 		fmt.Fprintf(os.Stdout, "Failed to config, exiting")
-		os.Exit(-1)
+		panic(err)
 	}
 
 	// Fire up the logging system
-	log, err := initLog(conf.LogConfig.LogLevel)
+	log, err := initLog(conf.S.Log.LogLevel)
 	if err != nil {
 		fmt.Printf("Failed to prep logger: %s", err.Error())
 		os.Exit(-1)
@@ -32,7 +32,7 @@ func InitMockResources(cfgPath string) *Resources {
 
 	r := &Resources{
 		Log:    log,
-		System: conf,
+		Config: conf,
 	}
 
 	// db and resources have cyclic pointers

--- a/database/resources.go
+++ b/database/resources.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,7 +21,7 @@ import (
 type (
 	// Resources provides a data structure for passing system Resources
 	Resources struct {
-		System *config.SystemConfig
+		Config *config.Config
 		Log    *log.Logger
 		DB     *DB
 		MetaDB *MetaDBHandle
@@ -33,24 +31,24 @@ type (
 // InitResources grabs the configuration file and intitializes the configuration data
 // returning a *Resources object which has all of the necessary configuration information
 func InitResources(cfgPath string) *Resources {
-	conf, ok := config.GetConfig(cfgPath)
-	if !ok {
+	conf, err := config.GetConfig(cfgPath)
+	if err != nil {
 		fmt.Fprintf(os.Stdout, "Failed to config, exiting")
-		os.Exit(-1)
+		panic(err)
 	}
 
 	// Fire up the logging system
-	log, err := initLog(conf.LogConfig.LogLevel)
+	log, err := initLog(conf.S.Log.LogLevel)
 	if err != nil {
 		fmt.Printf("Failed to prep logger: %s", err.Error())
 		os.Exit(-1)
 	}
-	if conf.LogConfig.LogToFile {
-		addFileLogger(log, conf.LogConfig.RitaLogPath)
+	if conf.S.Log.LogToFile {
+		addFileLogger(log, conf.S.Log.RitaLogPath)
 	}
 
 	// Jump into the requested database
-	session, err := connectToMongoDB(&conf.MongoDBConfig, log)
+	session, err := connectToMongoDB(&conf.S.MongoDB, &conf.R.MongoDB, log)
 	if err != nil {
 		fmt.Printf("Failed to connect to database: %s", err.Error())
 		os.Exit(-1)
@@ -66,14 +64,14 @@ func InitResources(cfgPath string) *Resources {
 
 	// Allows code to create and remove tracked databases
 	metaDB := &MetaDBHandle{
-		DB:   conf.BroConfig.MetaDB,
+		DB:   conf.S.Bro.MetaDB,
 		lock: new(sync.Mutex),
 	}
 
 	//bundle up the system resources
 	r := &Resources{
 		Log:    log,
-		System: conf,
+		Config: conf,
 	}
 
 	// db and resources have cyclic pointers
@@ -90,10 +88,10 @@ func InitResources(cfgPath string) *Resources {
 	}
 
 	//Begin logging to the metadatabase
-	if conf.LogConfig.LogToDB {
+	if conf.S.Log.LogToDB {
 		log.Hooks.Add(
 			mgorus.NewHookerFromSession(
-				session, conf.BroConfig.MetaDB, conf.LogConfig.RitaLogTable,
+				session, conf.S.Bro.MetaDB, conf.T.Log.RitaLogTable,
 			),
 		)
 	}
@@ -101,24 +99,13 @@ func InitResources(cfgPath string) *Resources {
 }
 
 //connectToMongoDB connects to MongoDB possibly with authentication and TLS
-func connectToMongoDB(conf *config.MongoDBCfg, logger *log.Logger) (*mgo.Session, error) {
-	if conf.TLS.Enabled {
-		tlsConf := &tls.Config{}
-		if len(conf.TLS.CAFile) > 0 {
-			pem, err := ioutil.ReadFile(conf.TLS.CAFile)
-			if err != nil {
-				logger.WithFields(log.Fields{
-					"CAFile": conf.TLS.CAFile,
-				}).Error(err.Error())
-				fmt.Println("[!] Could not read MongoDB CA file")
-			} else {
-				tlsConf.RootCAs = x509.NewCertPool()
-				tlsConf.RootCAs.AppendCertsFromPEM(pem)
-			}
-		}
-		return mgosec.Dial(conf.ConnectionString, conf.AuthMechanismParsed, tlsConf)
+func connectToMongoDB(static *config.MongoDBStaticCfg,
+	running *config.MongoDBRunningCfg,
+	logger *log.Logger) (*mgo.Session, error) {
+	if static.TLS.Enabled {
+		return mgosec.Dial(static.ConnectionString, running.AuthMechanismParsed, running.TLS.TLSConfig)
 	}
-	return mgosec.DialInsecure(conf.ConnectionString, conf.AuthMechanismParsed)
+	return mgosec.DialInsecure(static.ConnectionString, running.AuthMechanismParsed)
 }
 
 // initLog creates the logger for logging to stdout and file

--- a/database/resources.go
+++ b/database/resources.go
@@ -53,8 +53,8 @@ func InitResources(cfgPath string) *Resources {
 		fmt.Printf("Failed to connect to database: %s", err.Error())
 		os.Exit(-1)
 	}
-	session.SetSocketTimeout(conf.MongoDBConfig.SocketTimeout)
-	session.SetSyncTimeout(conf.MongoDBConfig.SocketTimeout)
+	session.SetSocketTimeout(conf.S.MongoDB.SocketTimeout)
+	session.SetSyncTimeout(conf.S.MongoDB.SocketTimeout)
 	session.SetCursorTimeout(0)
 
 	// Allows code to interact with the database

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -9,6 +9,8 @@ MongoDB:
   # For encrypting data on the wire between RITA and MongoDB
   TLS:
     Enable: false
+    #If set, RITA will verify the MongoDB certificate's hostname and validity
+    VerifyCertificate: false
     #If set, RITA will use the provided CA file instead of the system's CA's
     CAFile: null
 

--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -17,7 +17,7 @@ import (
 
 //newIndexedFile takes in a file path and the bro config and opens up the
 //file path and parses out some metadata
-func newIndexedFile(filePath string, config *config.SystemConfig,
+func newIndexedFile(filePath string, config *config.Config,
 	logger *log.Logger) (*fpt.IndexedFile, error) {
 	toReturn := new(fpt.IndexedFile)
 	toReturn.Path = filePath
@@ -76,13 +76,13 @@ func newIndexedFile(filePath string, config *config.SystemConfig,
 		return toReturn, errors.New("Could not parse first line of file for time")
 	}
 
-	toReturn.TargetCollection = line.TargetCollection(&config.StructureConfig)
+	toReturn.TargetCollection = line.TargetCollection(&config.T.Structure)
 	if toReturn.TargetCollection == "" {
 		fileHandle.Close()
 		return toReturn, errors.New("Could not find a target collection for file")
 	}
 
-	toReturn.TargetDatabase = getTargetDatabase(filePath, &config.BroConfig)
+	toReturn.TargetDatabase = getTargetDatabase(filePath, &config.S.Bro)
 	if toReturn.TargetDatabase == "" {
 		fileHandle.Close()
 		return toReturn, errors.New("Could not find a dataset for file")
@@ -113,7 +113,7 @@ func getFileHash(fileHandle *os.File, fInfo os.FileInfo) (string, error) {
 
 //getTargetDatabase assigns a database to a log file based on the path,
 //and the bro config
-func getTargetDatabase(path string, broConfig *config.BroCfg) string {
+func getTargetDatabase(path string, broConfig *config.BroStaticCfg) string {
 	// check the directory map
 	for key, val := range broConfig.DirectoryMap {
 		if strings.Contains(path, key) {

--- a/parser/parsetypes/conn.go
+++ b/parser/parsetypes/conn.go
@@ -57,7 +57,7 @@ type (
 
 //TargetCollection returns the mongo collection this entry should be inserted
 //into
-func (in *Conn) TargetCollection(config *config.StructureCfg) string {
+func (in *Conn) TargetCollection(config *config.StructureTableCfg) string {
 	return config.ConnTable
 }
 

--- a/parser/parsetypes/dns.go
+++ b/parser/parsetypes/dns.go
@@ -62,7 +62,7 @@ type DNS struct {
 
 //TargetCollection returns the mongo collection this entry should be inserted
 //into
-func (in *DNS) TargetCollection(config *config.StructureCfg) string {
+func (in *DNS) TargetCollection(config *config.StructureTableCfg) string {
 	return config.DNSTable
 }
 

--- a/parser/parsetypes/http.go
+++ b/parser/parsetypes/http.go
@@ -78,7 +78,7 @@ type HTTP struct {
 
 //TargetCollection returns the mongo collection this entry should be inserted
 //into
-func (line *HTTP) TargetCollection(config *config.StructureCfg) string {
+func (line *HTTP) TargetCollection(config *config.StructureTableCfg) string {
 	return config.HTTPTable
 }
 

--- a/parser/parsetypes/parsetypes.go
+++ b/parser/parsetypes/parsetypes.go
@@ -4,7 +4,7 @@ import "github.com/ocmdev/rita/config"
 
 //BroData holds a line of a bro log
 type BroData interface {
-	TargetCollection(*config.StructureCfg) string
+	TargetCollection(*config.StructureTableCfg) string
 	Indices() []string
 	Normalize()
 }

--- a/reporting/report-bl-dest-ips.go
+++ b/reporting/report-bl-dest-ips.go
@@ -21,13 +21,13 @@ func printBLDestIPs(db string, res *database.Resources) error {
 
 	var blIPs []blacklist.BlacklistedIP
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.DestIPsTable).
+		C(res.Config.T.Blacklisted.DestIPsTable).
 		Find(nil).Sort("-conn").All(&blIPs)
 
 	for i, ip := range blIPs {
 		var connected []structure.UniqueConnection
 		res.DB.Session.DB(db).
-			C(res.System.StructureConfig.UniqueConnTable).Find(
+			C(res.Config.T.Structure.UniqueConnTable).Find(
 			bson.M{"dst": ip.IP},
 		).All(&connected)
 		for _, uconn := range connected {

--- a/reporting/report-bl-hostnames.go
+++ b/reporting/report-bl-hostnames.go
@@ -24,7 +24,7 @@ func printBLHostnames(db string, res *database.Resources) error {
 
 	var blHosts []blacklist.BlacklistedHostname
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.HostnamesTable).
+		C(res.Config.T.Blacklisted.HostnamesTable).
 		Find(nil).Sort("-conn").All(&blHosts)
 
 	//for each blacklisted host
@@ -36,7 +36,7 @@ func printBLHostnames(db string, res *database.Resources) error {
 			//then find all of the hosts which talked to the ip
 			var connected []structure.UniqueConnection
 			res.DB.Session.DB(db).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"dst": ip},
 			).All(&connected)
 			//and aggregate the source ip addresses

--- a/reporting/report-bl-source-ips.go
+++ b/reporting/report-bl-source-ips.go
@@ -23,13 +23,13 @@ func printBLSourceIPs(db string, res *database.Resources) error {
 
 	var blIPs []blacklist.BlacklistedIP
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.SourceIPsTable).
+		C(res.Config.T.Blacklisted.SourceIPsTable).
 		Find(nil).Sort("-conn").All(&blIPs)
 
 	for i, ip := range blIPs {
 		var connected []structure.UniqueConnection
 		res.DB.Session.DB(db).
-			C(res.System.StructureConfig.UniqueConnTable).Find(
+			C(res.Config.T.Structure.UniqueConnTable).Find(
 			bson.M{"src": ip.IP},
 		).All(&connected)
 		for _, uconn := range connected {

--- a/reporting/report-bl-urls.go
+++ b/reporting/report-bl-urls.go
@@ -24,14 +24,14 @@ func printBLURLs(db string, res *database.Resources) error {
 
 	var blURLs []blacklist.BlacklistedURL
 	res.DB.Session.DB(db).
-		C(res.System.BlacklistedConfig.UrlsTable).
+		C(res.Config.T.Blacklisted.UrlsTable).
 		Find(nil).Sort("-conn").All(&blURLs)
 
 	//for each blacklisted url
 	for i, blURL := range blURLs {
 		//get the ips associated with the url
 		var urlEntry urls.URL
-		res.DB.Session.DB(db).C(res.System.UrlsConfig.UrlsTable).
+		res.DB.Session.DB(db).C(res.Config.T.Urls.UrlsTable).
 			Find(bson.M{"url": blURL.Host, "uri": blURL.Resource}).One(&urlEntry)
 		ips := urlEntry.IPs
 		//and loop over the ips
@@ -39,7 +39,7 @@ func printBLURLs(db string, res *database.Resources) error {
 			//then find all of the hosts which talked to the ip
 			var connected []structure.UniqueConnection
 			res.DB.Session.DB(db).
-				C(res.System.StructureConfig.UniqueConnTable).Find(
+				C(res.Config.T.Structure.UniqueConnTable).Find(
 				bson.M{"dst": ip},
 			).All(&connected)
 			//and aggregate the source ip addresses

--- a/reporting/report-explodedDns.go
+++ b/reporting/report-explodedDns.go
@@ -18,7 +18,7 @@ func printDNS(db string, res *database.Resources) error {
 	defer f.Close()
 
 	var results []dns.ExplodedDNS
-	iter := res.DB.Session.DB(db).C(res.System.DNSConfig.ExplodedDNSTable).Find(nil)
+	iter := res.DB.Session.DB(db).C(res.Config.T.DNS.ExplodedDNSTable).Find(nil)
 	iter.Sort("-subdomains").Limit(1000).All(&results)
 
 	out, err := template.New("dns.html").Parse(templates.DNStempl)

--- a/reporting/report-long-connections.go
+++ b/reporting/report-long-connections.go
@@ -22,7 +22,7 @@ func printLongConns(db string, res *database.Resources) error {
 	}
 
 	var conns []data.Conn
-	coll := res.DB.Session.DB(db).C(res.System.StructureConfig.ConnTable)
+	coll := res.DB.Session.DB(db).C(res.Config.T.Structure.ConnTable)
 	coll.Find(nil).Sort("-duration").Limit(1000).All(&conns)
 
 	w, err := getLongConnWriter(conns)

--- a/reporting/report-scans.go
+++ b/reporting/report-scans.go
@@ -24,7 +24,7 @@ func printScans(db string, res *database.Resources) error {
 	}
 
 	var scans []scanning.Scan
-	coll := res.DB.Session.DB(db).C(res.System.ScanningConfig.ScanTable)
+	coll := res.DB.Session.DB(db).C(res.Config.T.Scanning.ScanTable)
 	coll.Find(nil).All(&scans)
 
 	w, err := getScanWriter(scans)

--- a/reporting/report-urls.go
+++ b/reporting/report-urls.go
@@ -22,7 +22,7 @@ func printLongURLs(db string, res *database.Resources) error {
 	}
 
 	var urls []urls.URL
-	coll := res.DB.Session.DB(db).C(res.System.UrlsConfig.UrlsTable)
+	coll := res.DB.Session.DB(db).C(res.Config.T.Urls.UrlsTable)
 	coll.Find(nil).Sort("-length").Limit(1000).All(&urls)
 
 	w, err := getLongURLWriter(urls)

--- a/reporting/report-useragents.go
+++ b/reporting/report-useragents.go
@@ -22,7 +22,7 @@ func printUserAgents(db string, res *database.Resources) error {
 	}
 
 	var agents []useragent.UserAgent
-	coll := res.DB.Session.DB(db).C(res.System.UserAgentConfig.UserAgentTable)
+	coll := res.DB.Session.DB(db).C(res.Config.T.UserAgent.UserAgentTable)
 	coll.Find(nil).Sort("times_used").Limit(1000).All(&agents)
 
 	w, err := getUserAgentsWriter(agents)


### PR DESCRIPTION
This PR adds the option to prevent the verification of TLS certificates. 
This PR requires a [pull request in rita-bl](https://github.com/ocmdev/rita-bl/pull/2)

```
MongoDB:
  # See https://docs.mongodb.com/manual/reference/connection-string/
  ConnectionString: mongodb://localhost:27017
  # How to authenticate to MongoDB
  # Accepted Values: null, "SCRAM-SHA-1", "MONGODB-CR", "PLAIN"
  AuthenticationMechanism: null
  # For encrypting data on the wire between RITA and MongoDB
  TLS:
    Enable: false
    #If set, RITA will verify the MongoDB certificate's hostname and validity
    VerifyCertificate: false
    #If set, RITA will use the provided CA file instead of the system's CA's
    CAFile: null
```


This means that we need to parse multiple TLS settings and de-serialize them into Go's format.

Unfortunately, while the tls.Config can be built from a yaml file, you cannot save a tls.Config to a yaml file.

This lead to the splitting of the in memory representation of the RITA config. (Static and Running configs).

This allows us to safely serialize and de-serialize the static config, and keep parsed options separate.

Additionally, I took the time to separate out the table configuration since we are looking to split that off in the future.

The configuration has changed from 
```
	//SystemConfig is the container for other config sections
	SystemConfig struct {
		BatchSize         int            `yaml:"BatchSize"`
		MongoDBConfig     MongoDBCfg     `yaml:"MongoDB"`
		Prefetch          float64        `yaml:"Prefetch"`
		LogConfig         LogCfg         `yaml:"LogConfig"`
		BlacklistedConfig BlacklistedCfg `yaml:"BlackListed"`
		DNSConfig         DNSCfg         `yaml:"Dns"`
		CrossrefConfig    CrossrefCfg    `yaml:"Crossref"`
		ScanningConfig    ScanningCfg    `yaml:"Scanning"`
		StructureConfig   StructureCfg   `yaml:"Structure"`
		BeaconConfig      BeaconCfg      `yaml:"Beacon"`
		UrlsConfig        UrlsCfg        `yaml:"Urls"`
		UserAgentConfig   UserAgentCfg   `yaml:"UserAgent"`
		BroConfig         BroCfg         `yaml:"Bro"`
		MetaTables        MetaCfg        `yaml:"MetaTables"`
		Version           string
	}
```

To 

```
	//Config holds the configuration for the running system
	Config struct {
		R RunningCfg
		S StaticCfg
		T TableCfg
	}
```
```
	//RunningCfg holds configuration options that are parsed at run time
	RunningCfg struct {
		MongoDB MongoDBRunningCfg
		Version string
	}
```
```
	//StaticCfg is the container for other static config sections
	StaticCfg struct {
		MongoDB     MongoDBStaticCfg     `yaml:"MongoDB"`
		Log         LogStaticCfg         `yaml:"LogConfig"`
		Blacklisted BlacklistedStaticCfg `yaml:"BlackListed"`
		Crossref    CrossrefStaticCfg    `yaml:"Crossref"`
		Scanning    ScanningStaticCfg    `yaml:"Scanning"`
		Beacon      BeaconStaticCfg      `yaml:"Beacon"`
		Bro         BroStaticCfg         `yaml:"Bro"`
	}
```
```
	//TableCfg is the container for other table config sections
	TableCfg struct {
		Log         LogTableCfg         `yaml:"LogConfig"`
		Blacklisted BlacklistedTableCfg `yaml:"BlackListed"`
		DNS         DNSTableCfg         `yaml:"Dns"`
		Crossref    CrossrefTableCfg    `yaml:"Crossref"`
		Scanning    ScanningTableCfg    `yaml:"Scanning"`
		Structure   StructureTableCfg   `yaml:"Structure"`
		Beacon      BeaconTableCfg      `yaml:"Beacon"`
		Urls        UrlsTableCfg        `yaml:"Urls"`
		UserAgent   UserAgentTableCfg   `yaml:"UserAgent"`
		Meta        MetaTableCfg        `yaml:"MetaTables"`
	}
```