### PR TITLE
Prevent RITA from following symlink'd directories

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -101,7 +101,10 @@ func readDir(cpath string, logger *log.Logger) []string {
 	}
 
 	for _, file := range files {
-		if file.IsDir() {
+		// Stop RITA from following symlinks
+		// In the case that RITA is pointed directly at Bro, it should not
+		// parse the "current" symlink which points to the spool.
+		if file.IsDir() && file.Mode() != os.ModeSymlink {
 			toReturn = append(toReturn, readDir(path.Join(cpath, file.Name()), logger)...)
 		}
 		if strings.HasSuffix(file.Name(), "gz") ||


### PR DESCRIPTION
While parsing bro logs, I ran into an issue revolving around the current directory. RITA will parse the files in the current directory into the current day's database. Since this creates the database for the current day, when I go to parse the rest of the day's logs after they are archived, RITA fails.

A proposed solution: simply don't parse symlink'd directories.

(Perhaps this behaviour should be configurable?)