### PR TITLE
Added integer representations of the ip addresses in the hosts table

### DIFF
--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -1,8 +1,13 @@
 package structure
 
 import (
+	"encoding/binary"
+	"net"
+
 	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/database"
+	structureTypes "github.com/ocmdev/rita/datatypes/structure"
+	log "github.com/sirupsen/logrus"
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -27,8 +32,13 @@ func BuildHostsCollection(res *database.Resources) {
 	defer ssn.Close()
 
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
+	setIPv4Binary(res.DB.GetSelectedDB(), newCollectionName, ssn, res.Log)
+	setIPv6Binary(res.DB.GetSelectedDB(), newCollectionName, ssn, res.Log)
 }
 
+//getHosts aggregates the individual hosts from the conn collection and
+//labels them as private or public as well as ipv4 or ipv6. The aggregation
+//includes padding for a binary encoding of the ip address.
 func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	// Name of source collection which will be aggregated into the new collection
 	sourceCollectionName := conf.T.Structure.ConnTable
@@ -40,6 +50,7 @@ func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	keys := []mgo.Index{
 		{Key: []string{"ip"}, Unique: true},
 		{Key: []string{"local"}},
+		{Key: []string{"ipv4"}},
 	}
 
 	// Aggregation script
@@ -75,6 +86,26 @@ func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 				{"_id", 0},
 				{"ip", "$_id"},
 				{"local", 1},
+				{"ipv4", bson.D{
+					{"$cond", bson.D{
+						{"if", bson.D{
+							{"$eq", []interface{}{
+								bson.D{
+									{"$indexOfCP", []interface{}{
+										"$_id", ":",
+									}},
+								},
+								-1,
+							}},
+						}},
+						{"then", bson.D{
+							{"$literal", true},
+						}},
+						{"else", bson.D{
+							{"$literal", false},
+						}},
+					}},
+				}},
 			}},
 		},
 		{
@@ -83,4 +114,121 @@ func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	}
 
 	return sourceCollectionName, newCollectionName, keys, pipeline
+}
+
+//setIPv4Binary sets the binary data for the ipv4 addresses in the dataset
+func setIPv4Binary(selectedDB string, collectionName string,
+	session *mgo.Session, logger *log.Logger) {
+	coll := session.DB(selectedDB).C(collectionName)
+
+	i := 0
+
+	var host structureTypes.Host
+	iter := coll.Find(bson.D{{"ipv4", true}}).Snapshot().Iter() //nolint: vet
+
+	bulkUpdate := coll.Bulk()
+
+	for iter.Next(&host) {
+		//1000 is the most a MongoDB bulk update operation can handle
+		if i == 1000 {
+			bulkUpdate.Unordered()
+			_, err := bulkUpdate.Run()
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("Unable to write binary representation of IP addresses")
+			}
+
+			bulkUpdate = coll.Bulk()
+			i = 0
+		}
+
+		ipv4 := net.ParseIP(host.Ip)
+		ipv4Binary := uint64(binary.BigEndian.Uint32(ipv4[12:16]))
+
+		//nolint: vet
+		bulkUpdate.Update(
+			bson.D{
+				{"_id", host.ID},
+			},
+			bson.D{
+				{"$set", bson.D{
+					{"ipv4_binary", ipv4Binary},
+				}},
+			},
+		)
+		i++
+	}
+
+	//guaranteed to be at least one in the array
+	bulkUpdate.Unordered()
+	_, err := bulkUpdate.Run()
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to write binary representation of IP addresses")
+	}
+}
+
+//setIPv6Binary sets the binary data for the ipv6 addresses in the dataset
+func setIPv6Binary(selectedDB string, collectionName string,
+	session *mgo.Session, logger *log.Logger) {
+	coll := session.DB(selectedDB).C(collectionName)
+
+	i := 0
+
+	var host structureTypes.Host
+	iter := coll.Find(bson.D{{"ipv4", false}}).Snapshot().Iter() //nolint: vet
+
+	bulkUpdate := coll.Bulk()
+
+	for iter.Next(&host) {
+		//1000 is the most a MongoDB bulk update operation can handle
+		if i == 1000 {
+			bulkUpdate.Unordered()
+			_, err := bulkUpdate.Run()
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("Unable to write binary representation of IP addresses")
+			}
+
+			bulkUpdate = coll.Bulk()
+			i = 0
+		}
+
+		ipv6 := net.ParseIP(host.Ip)
+		ipv6Binary1 := uint64(binary.BigEndian.Uint32(ipv6[0:4]))
+		ipv6Binary2 := uint64(binary.BigEndian.Uint32(ipv6[4:8]))
+		ipv6Binary3 := uint64(binary.BigEndian.Uint32(ipv6[8:12]))
+		ipv6Binary4 := uint64(binary.BigEndian.Uint32(ipv6[12:16]))
+
+		//nolint: vet
+		bulkUpdate.Update(
+			bson.D{
+				{"_id", host.ID},
+			},
+			bson.D{
+				{"$set", bson.D{
+					{"ipv6_binary", bson.D{
+						{"1", ipv6Binary1},
+						{"2", ipv6Binary2},
+						{"3", ipv6Binary3},
+						{"4", ipv6Binary4},
+					}},
+				}},
+			},
+		)
+
+		i++
+	}
+
+	//guaranteed to be at least one in the array
+	bulkUpdate.Unordered()
+	_, err := bulkUpdate.Run()
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to write binary representation of IP addresses")
+	}
 }

--- a/datatypes/structure/structure.go
+++ b/datatypes/structure/structure.go
@@ -5,11 +5,17 @@ import (
 )
 
 type (
+	//Host describes a computer interface found in the
+	//network traffic being analyzed
 	Host struct {
+		ID    bson.ObjectId `bson:"_id,omitempty"`
 		Ip    string        `bson:"ip"`
 		Local bool          `bson:"local"`
+		IPv4  bool          `bson:"ipv6"`
 	}
 
+	//UniqueConnection describes a pair of computer interfaces which contacted
+	//each other over the observation period
 	UniqueConnection struct {
 		ID              bson.ObjectId `bson:"_id,omitempty"`
 		ConnectionCount int           `bson:"connection_count"`


### PR DESCRIPTION
Add ipv4, ipv4_binary, and ipv6_binary fields to the hosts table. IPv4 addresses are stored as 64 bit numbers since MongoDB uses signed integers only. IPv6 addresses are stored as objects with four 64 bit numbers each holding a 32 bit number representing a fourth of the address.