### PR TITLE
Split integer representations of IP addresses into their own collections

### DIFF
--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -1,13 +1,8 @@
 package structure
 
 import (
-	"encoding/binary"
-	"net"
-
 	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/database"
-	structureTypes "github.com/ocmdev/rita/datatypes/structure"
-	log "github.com/sirupsen/logrus"
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -19,7 +14,7 @@ func BuildHostsCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipeline := getHosts(res.Config)
+		pipseline := getHosts(res.Config)
 
 	// Aggregate it!
 	errorCheck := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
@@ -32,8 +27,6 @@ func BuildHostsCollection(res *database.Resources) {
 	defer ssn.Close()
 
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
-	setIPv4Binary(res.DB.GetSelectedDB(), newCollectionName, ssn, res.Log)
-	setIPv6Binary(res.DB.GetSelectedDB(), newCollectionName, ssn, res.Log)
 }
 
 //getHosts aggregates the individual hosts from the conn collection and
@@ -114,121 +107,4 @@ func getHosts(conf *config.Config) (string, string, []mgo.Index, []bson.D) {
 	}
 
 	return sourceCollectionName, newCollectionName, keys, pipeline
-}
-
-//setIPv4Binary sets the binary data for the ipv4 addresses in the dataset
-func setIPv4Binary(selectedDB string, collectionName string,
-	session *mgo.Session, logger *log.Logger) {
-	coll := session.DB(selectedDB).C(collectionName)
-
-	i := 0
-
-	var host structureTypes.Host
-	iter := coll.Find(bson.D{{"ipv4", true}}).Snapshot().Iter() //nolint: vet
-
-	bulkUpdate := coll.Bulk()
-
-	for iter.Next(&host) {
-		//1000 is the most a MongoDB bulk update operation can handle
-		if i == 1000 {
-			bulkUpdate.Unordered()
-			_, err := bulkUpdate.Run()
-			if err != nil {
-				logger.WithFields(log.Fields{
-					"error": err.Error(),
-				}).Error("Unable to write binary representation of IP addresses")
-			}
-
-			bulkUpdate = coll.Bulk()
-			i = 0
-		}
-
-		ipv4 := net.ParseIP(host.IP)
-		ipv4Binary := uint64(binary.BigEndian.Uint32(ipv4[12:16]))
-
-		//nolint: vet
-		bulkUpdate.Update(
-			bson.D{
-				{"_id", host.ID},
-			},
-			bson.D{
-				{"$set", bson.D{
-					{"ipv4_binary", ipv4Binary},
-				}},
-			},
-		)
-		i++
-	}
-
-	//guaranteed to be at least one in the array
-	bulkUpdate.Unordered()
-	_, err := bulkUpdate.Run()
-	if err != nil {
-		logger.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Error("Unable to write binary representation of IP addresses")
-	}
-}
-
-//setIPv6Binary sets the binary data for the ipv6 addresses in the dataset
-func setIPv6Binary(selectedDB string, collectionName string,
-	session *mgo.Session, logger *log.Logger) {
-	coll := session.DB(selectedDB).C(collectionName)
-
-	i := 0
-
-	var host structureTypes.Host
-	iter := coll.Find(bson.D{{"ipv4", false}}).Snapshot().Iter() //nolint: vet
-
-	bulkUpdate := coll.Bulk()
-
-	for iter.Next(&host) {
-		//1000 is the most a MongoDB bulk update operation can handle
-		if i == 1000 {
-			bulkUpdate.Unordered()
-			_, err := bulkUpdate.Run()
-			if err != nil {
-				logger.WithFields(log.Fields{
-					"error": err.Error(),
-				}).Error("Unable to write binary representation of IP addresses")
-			}
-
-			bulkUpdate = coll.Bulk()
-			i = 0
-		}
-
-		ipv6 := net.ParseIP(host.IP)
-		ipv6Binary1 := uint64(binary.BigEndian.Uint32(ipv6[0:4]))
-		ipv6Binary2 := uint64(binary.BigEndian.Uint32(ipv6[4:8]))
-		ipv6Binary3 := uint64(binary.BigEndian.Uint32(ipv6[8:12]))
-		ipv6Binary4 := uint64(binary.BigEndian.Uint32(ipv6[12:16]))
-
-		//nolint: vet
-		bulkUpdate.Update(
-			bson.D{
-				{"_id", host.ID},
-			},
-			bson.D{
-				{"$set", bson.D{
-					{"ipv6_binary", bson.D{
-						{"1", ipv6Binary1},
-						{"2", ipv6Binary2},
-						{"3", ipv6Binary3},
-						{"4", ipv6Binary4},
-					}},
-				}},
-			},
-		)
-
-		i++
-	}
-
-	//guaranteed to be at least one in the array
-	bulkUpdate.Unordered()
-	_, err := bulkUpdate.Run()
-	if err != nil {
-		logger.WithFields(log.Fields{
-			"error": err.Error(),
-		}).Error("Unable to write binary representation of IP addresses")
-	}
 }

--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -14,7 +14,7 @@ func BuildHostsCollection(res *database.Resources) {
 	sourceCollectionName,
 		newCollectionName,
 		newCollectionKeys,
-		pipseline := getHosts(res.Config)
+		pipeline := getHosts(res.Config)
 
 	// Aggregate it!
 	errorCheck := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)

--- a/analysis/structure/ip.go
+++ b/analysis/structure/ip.go
@@ -1,0 +1,174 @@
+package structure
+
+import (
+	"encoding/binary"
+	"net"
+
+	"github.com/ocmdev/rita/database"
+	structureTypes "github.com/ocmdev/rita/datatypes/structure"
+	log "github.com/sirupsen/logrus"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+//BuildIPv4Collection generates binary representations of the IPv4 addresses in the
+//dataset for use in subnetting, address selection, etc.
+func BuildIPv4Collection(res *database.Resources) {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	errorCheck := res.DB.CreateCollection(
+		res.Config.T.Structure.IPv4Table,
+		false,
+		[]mgo.Index{
+			{Key: []string{"ip"}, Unique: true},
+			{Key: []string{"ipv4_binary"}},
+		},
+	)
+	if errorCheck != nil {
+		res.Log.Error("Failed: ", res.Config.T.Structure.IPv4Table, errorCheck)
+		return
+	}
+
+	buildIPv4Binary(
+		res.DB.GetSelectedDB(),
+		res.Config.T.Structure.HostTable,
+		res.Config.T.Structure.IPv4Table,
+		ssn,
+		res.Log,
+	)
+}
+
+//BuildIPv6Collection generates binary representations of the IPv6 addresses in the
+//dataset for use in subnetting, address selection, etc.
+func BuildIPv6Collection(res *database.Resources) {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	errorCheck := res.DB.CreateCollection(
+		res.Config.T.Structure.IPv6Table,
+		false,
+		[]mgo.Index{
+			{Key: []string{"ip"}, Unique: true},
+			{Key: []string{"ipv6_binary.1"}},
+			{Key: []string{"ipv6_binary.2"}},
+			{Key: []string{"ipv6_binary.3"}},
+			{Key: []string{"ipv6_binary.4"}},
+		},
+	)
+	if errorCheck != nil {
+		res.Log.Error("Failed: ", res.Config.T.Structure.IPv6Table, errorCheck)
+		return
+	}
+
+	buildIPv6Binary(
+		res.DB.GetSelectedDB(),
+		res.Config.T.Structure.HostTable,
+		res.Config.T.Structure.IPv6Table,
+		ssn,
+		res.Log,
+	)
+}
+
+//buildIPv4Binary sets the binary data for the ipv4 addresses in the dataset
+func buildIPv4Binary(selectedDB, hostCollection, destCollection string,
+	session *mgo.Session, logger *log.Logger) {
+	srcColl := session.DB(selectedDB).C(hostCollection)
+	destColl := session.DB(selectedDB).C(destCollection)
+	i := 0
+
+	var host structureTypes.Host
+	iter := srcColl.Find(bson.D{{"ipv4", true}}).Iter() //nolint: vet
+
+	bulkUpdate := destColl.Bulk()
+
+	for iter.Next(&host) {
+		//1000 is the most a MongoDB bulk update operation can handle
+		if i == 1000 {
+			bulkUpdate.Unordered()
+			_, err := bulkUpdate.Run()
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("Unable to write binary representation of IP addresses")
+			}
+
+			bulkUpdate = destColl.Bulk()
+			i = 0
+		}
+
+		ipv4 := net.ParseIP(host.IP)
+		ipv4Struct := structureTypes.IPv4Binary{
+			IP:         host.IP,
+			IPv4Binary: int64(binary.BigEndian.Uint32(ipv4[12:16])),
+		}
+		bulkUpdate.Insert(ipv4Struct)
+
+		i++
+	}
+
+	//guaranteed to be at least one in the array
+	bulkUpdate.Unordered()
+	_, err := bulkUpdate.Run()
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to write binary representation of IP addresses")
+	}
+}
+
+//buildIPv6Binary sets the binary data for the ipv6 addresses in the dataset
+func buildIPv6Binary(selectedDB, hostCollection, destCollection string,
+	session *mgo.Session, logger *log.Logger) {
+	srcColl := session.DB(selectedDB).C(hostCollection)
+	destColl := session.DB(selectedDB).C(destCollection)
+	i := 0
+
+	var host structureTypes.Host
+	iter := srcColl.Find(bson.D{{"ipv4", false}}).Iter() //nolint: vet
+
+	bulkUpdate := destColl.Bulk()
+
+	for iter.Next(&host) {
+		//1000 is the most a MongoDB bulk update operation can handle
+		if i == 1000 {
+			bulkUpdate.Unordered()
+			_, err := bulkUpdate.Run()
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("Unable to write binary representation of IP addresses")
+			}
+
+			bulkUpdate = destColl.Bulk()
+			i = 0
+		}
+
+		ipv6 := net.ParseIP(host.IP)
+		ipv6Binary1 := int64(binary.BigEndian.Uint32(ipv6[0:4]))
+		ipv6Binary2 := int64(binary.BigEndian.Uint32(ipv6[4:8]))
+		ipv6Binary3 := int64(binary.BigEndian.Uint32(ipv6[8:12]))
+		ipv6Binary4 := int64(binary.BigEndian.Uint32(ipv6[12:16]))
+		ipv6Struct := structureTypes.IPv6Binary{
+			IP: host.IP,
+			IPv6Binary: structureTypes.IPv6Integers{
+				I1: ipv6Binary1,
+				I2: ipv6Binary2,
+				I3: ipv6Binary3,
+				I4: ipv6Binary4,
+			},
+		}
+		bulkUpdate.Insert(ipv6Struct)
+
+		i++
+	}
+
+	//guaranteed to be at least one in the array
+	bulkUpdate.Unordered()
+	_, err := bulkUpdate.Run()
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to write binary representation of IP addresses")
+	}
+}

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -83,6 +83,12 @@ func analyze(inDb string, configFile string) error {
 		logAnalysisFunc("Unique Hosts", td, res,
 			structure.BuildHostsCollection,
 		)
+		logAnalysisFunc("IPv4 Conversion", td, res,
+			structure.BuildIPv4Collection,
+		)
+		logAnalysisFunc("IPv6 Conversion", td, res,
+			structure.BuildIPv6Collection,
+		)
 		logAnalysisFunc("Unique Hostnames", td, res,
 			dns.BuildHostnamesCollection,
 		)

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -81,13 +81,11 @@ func analyze(inDb string, configFile string) error {
 			structure.BuildUniqueConnectionsCollection,
 		)
 		logAnalysisFunc("Unique Hosts", td, res,
-			structure.BuildHostsCollection,
-		)
-		logAnalysisFunc("IPv4 Conversion", td, res,
-			structure.BuildIPv4Collection,
-		)
-		logAnalysisFunc("IPv6 Conversion", td, res,
-			structure.BuildIPv6Collection,
+			func(innerRes *database.Resources) {
+				structure.BuildHostsCollection(innerRes)
+				structure.BuildIPv4Collection(innerRes)
+				structure.BuildIPv6Collection(innerRes)
+			},
 		)
 		logAnalysisFunc("Unique Hostnames", td, res,
 			dns.BuildHostnamesCollection,

--- a/config/tables.go
+++ b/config/tables.go
@@ -36,6 +36,8 @@ type (
 		DNSTable        string `yaml:"DnsTable"`
 		UniqueConnTable string `yaml:"UniqueConnectionTable"`
 		HostTable       string `yaml:"HostTable"`
+		IPv4Table       string `yaml:"IPv4Table"`
+		IPv6Table       string `yaml:"IPv6Table"`
 	}
 
 	//BlacklistedTableCfg is used to control the blacklisted analysis module

--- a/datatypes/structure/structure.go
+++ b/datatypes/structure/structure.go
@@ -14,6 +14,33 @@ type (
 		IPv4  bool          `bson:"ipv6"`
 	}
 
+	//IPv4Binary provides a way to store a binary representation of an
+	//IPv4 address in MongoDB
+	IPv4Binary struct {
+		ID         bson.ObjectId `bson:"_id,omitempty"`
+		IP         string        `bson:"ip"`
+		IPv4Binary int64         `bson:"ipv4_binary"`
+	}
+
+	//IPv6Integers provides a way to store a binary representation of an
+	//IPv6 address in MongoDB. The 128 bit address is split into four 32 bit
+	//values. However, MongoDB cannot store unsigned numbers, so we use 64 bit
+	//integers to hold the values.
+	IPv6Integers struct {
+		I1 int64 `bson:"1"`
+		I2 int64 `bson:"2"`
+		I3 int64 `bson:"3"`
+		I4 int64 `bson:"4"`
+	}
+
+	//IPv6Binary provides a way to store a binary representation of an
+	//IPv6 address in MongoDB.
+	IPv6Binary struct {
+		ID         bson.ObjectId `bson:"_id,omitempty"`
+		IP         string        `bson:"ip"`
+		IPv6Binary IPv6Integers  `bson:"ipv6_binary"`
+	}
+
 	//UniqueConnection describes a pair of computer interfaces which contacted
 	//each other over the observation period
 	UniqueConnection struct {

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -1,7 +1,7 @@
 MongoDB:
     # See https://docs.mongodb.com/manual/reference/connection-string/
     ConnectionString: mongodb://localhost:27017
-    # Example with authentication. Be sure to change the AuthenticationMechanism as well. 
+    # Example with authentication. Be sure to change the AuthenticationMechanism as well.
     # ConnectionString: mongodb://username:password@localhost:27017
 
     # Accepted Values: null, "SCRAM-SHA-1", "MONGODB-CR", "PLAIN"

--- a/etc/tables.yaml
+++ b/etc/tables.yaml
@@ -8,6 +8,8 @@ Structure:
     DnsTable: dns
     UniqueConnectionTable: uconn
     HostTable: host
+    IPv4Table: ipv4
+    IPv6Table: ipv6
 
 BlackListed:
     Database: rita-blacklist
@@ -39,4 +41,3 @@ UserAgent:
 MetaTables:
     FilesTable: files
     DatabasesTable: databases
-


### PR DESCRIPTION
Note: this changes etc/rita.yaml, and as such will affect the split config PR.