### PR TITLE
Versioning Update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/blang/semver"
+  packages = ["."]
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
@@ -143,6 +149,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "832dc7b3f46a9078eacd699113f3f63b3a214fbeb79a8d164b9a71151c5395b4"
+  inputs-digest = "faeb74ddc998410e81792434cdede82704ed7479eb84d31e1cc20b2db67a8901"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-VERSION := $(shell git describe --always --long --dirty --tags)
+VERSION := $(shell git describe --abbrev=0 --tags)
+EXACT_VERSION := $(shell git describe --always --long --dirty --tags)
 GOPATH := $(GOPATH)
 BINARY := rita
 
-LDFLAGS=-ldflags="-X github.com/ocmdev/rita/config.VERSION=${VERSION}"
+LDFLAGS=-ldflags="-X github.com/ocmdev/rita/config.Version=${VERSION} -X github.com/ocmdev/rita/config.ExactVersion=${EXACT_VERSION}"
 
 
 default:
@@ -14,4 +15,3 @@ default:
 install:
 	dep ensure
 	go build ${LDFLAGS} -o ${GOPATH}/bin/${BINARY}
-

--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,13 @@ import (
 	"reflect"
 )
 
-//VERSION is filled at compile time with the git version of RITA
-var VERSION = "undefined"
+//Version is filled at compile time with the git version of RITA
+//Version is filled by "git describe --abbrev=0 --tags"
+var Version = "undefined"
+
+//ExactVersion is filled at compile time with the git version of RITA
+//ExactVersion is filled by "git describe --always --long --dirty --tags"
+var ExactVersion = "undefined"
 
 type (
 	//Config holds the configuration for the running system
@@ -19,7 +24,12 @@ type (
 	}
 )
 
+//userConfigPath specifies the path of RITA's static config file
+//relative to the user's home directory
 const userConfigPath = "/.rita/config.yaml"
+
+//tableConfigPath specifies teh path of RITA's table config file
+//relative to the user's home directory
 const tableConfigPath = "/.rita/tables.yaml"
 
 //NOTE: If go ever gets default parameters, default the config options to ""

--- a/config/running.go
+++ b/config/running.go
@@ -13,7 +13,6 @@ type (
 	//RunningCfg holds configuration options that are parsed at run time
 	RunningCfg struct {
 		MongoDB MongoDBRunningCfg
-		Version string
 	}
 
 	//MongoDBRunningCfg holds parsed information for connecting to MongoDB
@@ -29,8 +28,6 @@ type (
 func loadRunningConfig(config *StaticCfg) (*RunningCfg, error) {
 	var outConfig = new(RunningCfg)
 	var err error
-
-	outConfig.Version = VERSION
 
 	//parse the tls configuration
 	if config.MongoDB.TLS.Enabled {

--- a/config/running.go
+++ b/config/running.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/blang/semver"
 	"github.com/ocmdev/mgosec"
 )
 
@@ -13,6 +14,7 @@ type (
 	//RunningCfg holds configuration options that are parsed at run time
 	RunningCfg struct {
 		MongoDB MongoDBRunningCfg
+		Version semver.Version
 	}
 
 	//MongoDBRunningCfg holds parsed information for connecting to MongoDB
@@ -58,5 +60,6 @@ func loadRunningConfig(config *StaticCfg) (*RunningCfg, error) {
 	}
 	outConfig.MongoDB.AuthMechanismParsed = authMechanism
 
+	outConfig.Version, err = semver.ParseTolerant(config.Version)
 	return outConfig, err
 }

--- a/config/static.go
+++ b/config/static.go
@@ -13,13 +13,15 @@ import (
 type (
 	//StaticCfg is the container for other static config sections
 	StaticCfg struct {
-		MongoDB     MongoDBStaticCfg     `yaml:"MongoDB"`
-		Log         LogStaticCfg         `yaml:"LogConfig"`
-		Blacklisted BlacklistedStaticCfg `yaml:"BlackListed"`
-		Crossref    CrossrefStaticCfg    `yaml:"Crossref"`
-		Scanning    ScanningStaticCfg    `yaml:"Scanning"`
-		Beacon      BeaconStaticCfg      `yaml:"Beacon"`
-		Bro         BroStaticCfg         `yaml:"Bro"`
+		MongoDB      MongoDBStaticCfg     `yaml:"MongoDB"`
+		Log          LogStaticCfg         `yaml:"LogConfig"`
+		Blacklisted  BlacklistedStaticCfg `yaml:"BlackListed"`
+		Crossref     CrossrefStaticCfg    `yaml:"Crossref"`
+		Scanning     ScanningStaticCfg    `yaml:"Scanning"`
+		Beacon       BeaconStaticCfg      `yaml:"Beacon"`
+		Bro          BroStaticCfg         `yaml:"Bro"`
+		Version      string
+		ExactVersion string
 	}
 
 	//MongoDBStaticCfg contains the means for connecting to MongoDB
@@ -115,6 +117,10 @@ func loadStaticConfig(cfgPath string) (*StaticCfg, error) {
 
 	// set the socket time out in hours
 	config.MongoDB.SocketTimeout *= time.Hour
+
+	// grab the version constants set by the build process
+	config.Version = Version
+	config.ExactVersion = ExactVersion
 
 	return config, nil
 }

--- a/rita.go
+++ b/rita.go
@@ -17,7 +17,7 @@ func main() {
 
 	// Change the version string with updates so that a quick help command will
 	// let the testers know what version of HT they're on
-	app.Version = config.VERSION
+	app.Version = config.Version
 
 	// Define commands used with this application
 	app.Commands = commands.Commands()


### PR DESCRIPTION
Added better support for semver in RITA. RITA now stores two version tags, one with the latest tag (latest semver version), and one with exact commit details (ExactVersion). Additionally, RITA will check for incompatibilities at parse time and import time. If RITA attempts to import data into an unanalyzed, incompatible database, it will log out an error (PS we should probably add a log hook for errors to get get printed to the console). Further more, if RITA attempts to analyze a dataset imported with an incompatible version of RITA, the software will warn the user, and skip the analysis. 