### PR TITLE
Add the ability to split logs into dbs by subfolder, clean up the cli

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,6 @@ Additional functionality is being developed and will be included soon.
 * Clone the package:
 `git clone https://github.com/ocmdev/rita.git`
 * Change into the source directory: `cd rita`
-* Make the installer executable: `chmod +x install.sh`
 * Run the installer: `sudo ./install.sh`
 * Source your .bashrc (the installer added RITA to the PATH): `source ~/.bashrc`
 * Start MongoDB: `sudo service mongod start`
@@ -36,7 +35,7 @@ To install each component of RITA by hand, [check out the instructions in the wi
 ### Configuration File
 RITA contains a yaml format configuration file.
 
-You can specify the location for the configuration file with the **-c** command line flag. If not specified, RITA will first look for the configuration in **~/.rita/config.yaml** then **/etc/rita/config.yaml**.
+You can specify the location for the configuration file with the **-c** command line flag. If not specified, RITA will look for the configuration in **/etc/rita/config.yaml**.
 
 
 ### API Keys
@@ -65,50 +64,29 @@ To obtain an API key:
       * ```bro -r pcap_to_log.pcap local "Site::local_nets += { 192.168.0.0/24 }"  "Log::default_rotation_interval = 1 day"```
 
   * **Option 2**: Install Bro and let it monitor an interface directly [[instructions](https://www.bro.org/sphinx/quickstart/)]
-      * You may wish to [compile Bro from source](https://www.bro.org/sphinx/install/install.html) for performance reasons
+      * You may wish to [compile Bro from source](https://www.bro.org/sphinx/install/install.html) for performance reasons. [This script](https://github.com/ocmdev/bro-install) can help automate the process.
       * The automated installer for RITA installs pre-compiled Bro binaries
 
 #### Importing Data Into RITA
-  * After installing, `rita` should be in your `PATH`
+  * After installing, `rita` should be in your `PATH` and the config file should be set up ready to go. Once your Bro install has collected some logs (Bro will normally rotate logs on the hour) you can run `rita import`. Alternatively, you can manually import existing logs using one of the following options:
   * **Option 1**: Import directly from the terminal (one time import)
-    * `rita import -i path/to/your/bro_logs/ -d dataset_name`
-  * **Option 2**: Set up the Bro configuration in `~/.rita/config.yaml` for repeated imports
-    * Set `LogPath` to the `path/to/your/bro_logs`
-    * Set `DBPrefix` to an identifier common to your set of logs
-    * Set up the `DirectoryMap`
-      * Logs found in folders which match the substring on the left are imported
-      into  the dataset on the right
-    * Example
-      * Say you have two sets of logs to analyze
-        * `/share/bro_logs/networkA`
-        * `/share/bro_logs/networkB`
-      * A correct Bro config section would look like
-      ```yaml
-      Bro:
-          LogPath: /share/bro_logs/
-          DBPrefix: MyCompany_
-          DirectoryMap:
-            networkA: A
-            networkB: B
-      ```
-      * This would import `/share/brologs/networkA` into `MyCompany_A` and
-      `/share/brologs/networkB` into `MyCompany_B`
-
+    * `rita import path/to/your/bro_logs/ database_name`
+  * **Option 2**: Set up the Bro configuration in `/etc/rita/config.yaml` for repeated imports
+    * Set `ImportDirectory` to the `path/to/your/bro_logs`. The default is `/opt/bro/logs`
+    * Set `DBRoot` to an identifier common to your set of logs
 
 #### Analyzing Data With RITA
   * **Option 1**: Analyze one dataset
-    * `rita analyze -d dataset_name`
-    * Ex: `rita analyze -d MyCompany_A`
+    * `rita analyze dataset_name`
+    * Ex: `rita analyze MyCompany_A`
   * **Option 2**: Analyze all imported datasets
     * `rita analyze`
 
 #### Examining Data With RITA
   * Use the **show-X** commands
   * `-H` displays human readable data
-  * `rita show-beacons -d dataset_name -H`
-  * `rita show-blacklisted -d dataset_name -H`
-
-**A link to a video tutorial will be added soon!**
+  * `rita show-beacons dataset_name -H`
+  * `rita show-blacklisted dataset_name -H`
 
 ### Getting help
 Head over to [OFTC and join #ocmdev](https://webchat.oftc.net/?channels=ocmdev) for any questions you may have.

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -21,14 +21,14 @@ import (
 
 func init() {
 	analyzeCommand := cli.Command{
-		Name:  "analyze",
-		Usage: "Analyze imported databases, if no [database,d] flag is specified will attempt all",
+		Name:      "analyze",
+		Usage:     "Analyze imported databases. If no database is specified, every database will be analyzed.",
+		ArgsUsage: "[database]",
 		Flags: []cli.Flag{
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			return analyze(c.String("database"), c.String("config"))
+			return analyze(c.Args().Get(0), c.String("config"))
 		},
 	}
 

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -21,9 +21,10 @@ import (
 
 func init() {
 	analyzeCommand := cli.Command{
-		Name:      "analyze",
-		Usage:     "Analyze imported databases. If no database is specified, every database will be analyzed.",
-		ArgsUsage: "[database]",
+		Name:  "analyze",
+		Usage: "Analyze imported databases",
+		UsageText: "rita analyze [command options] [database]\n\n" +
+			"If no database is specified, every database will be analyzed.",
 		Flags: []cli.Flag{
 			configFlag,
 		},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,24 +12,17 @@ var (
 
 	// below are some prebuilt flags that get used often in various commands
 
-	// databaseFlag allows users to specify which database they'd like to use
-	databaseFlag = cli.StringFlag{
-		Name:  "database, d",
-		Usage: "execute this command against the database named `NAME`",
-		Value: "",
-	}
-
 	// threadFlag allows users to specify how many threads should be used
 	threadFlag = cli.IntFlag{
 		Name:  "threads, t",
-		Usage: "use `N` threads when executing this command",
+		Usage: "Use `N` threads when executing this command",
 		Value: runtime.NumCPU(),
 	}
 
 	// configFlag allows users to specify an alternate config file to use
 	configFlag = cli.StringFlag{
 		Name:  "config, c",
-		Usage: "use `CONFIGFILE` as configuration when running this command",
+		Usage: "Use a given `CONFIG_FILE` when running this command",
 		Value: "",
 	}
 
@@ -37,7 +30,7 @@ var (
 	// report instead of the simple csv style output
 	humanFlag = cli.BoolFlag{
 		Name:  "human-readable, H",
-		Usage: "print a report instead of csv",
+		Usage: "Print a report instead of csv",
 	}
 
 	blSortFlag = cli.StringFlag{

--- a/commands/delete-database.go
+++ b/commands/delete-database.go
@@ -13,19 +13,20 @@ import (
 
 func init() {
 	reset := cli.Command{
-		Name:  "delete-database",
-		Usage: "Delete an imported database",
+		Name:      "delete-database",
+		Usage:     "Delete an imported database",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			res := database.InitResources(c.String("config"))
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
-			fmt.Println("Are you sure you want to delete database", c.String("database"), "[Y/n]")
+			fmt.Print("Are you sure you want to delete database ", db, " [y/N] ")
 
 			read := bufio.NewReader(os.Stdin)
 
@@ -36,13 +37,15 @@ func init() {
 			response = strings.ToLower(strings.TrimSpace(response))
 
 			if response == "y" || response == "yes" {
-				fmt.Println("Deleting database:", c.String("database"))
-				return res.MetaDB.DeleteDB(c.String("database"))
-			} else if response == "n" || response == "no" {
-				return cli.NewExitError("Database "+c.String("database")+" was not deleted.", 0)
+				fmt.Println("Deleting database:", db)
+				err = res.MetaDB.DeleteDB(db)
+				if err != nil {
+					return cli.NewExitError("ERROR: "+err.Error(), -1)
+				}
 			} else {
-				return cli.NewExitError("Aborted, nothing deleted.", -1)
+				return cli.NewExitError("Database "+db+" was not deleted.", 0)
 			}
+			return nil
 		},
 	}
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/database"
 	"github.com/ocmdev/rita/parser"
 	"github.com/ocmdev/rita/util"
@@ -11,19 +14,15 @@ import (
 
 func init() {
 	importCommand := cli.Command{
-		Name:  "import",
-		Usage: "Import bro logs into the database",
+		Name:      "import",
+		Usage:     "Import bro logs into a database",
+		ArgsUsage: "<directory to import> <target database>",
 		Flags: []cli.Flag{
 			threadFlag,
 			configFlag,
 			cli.StringFlag{
-				Name:  "import-dir, i",
-				Usage: "Import bro logs from a `directory` into a database. This overides the config file. Must be used with --database, -d",
-				Value: "",
-			},
-			cli.StringFlag{
-				Name:  "database, d",
-				Usage: "Store imported bro logs into a database with the given `name`. This overides the config file. Must be used with --import-dir, -i",
+				Name:  "split, s",
+				Usage: "Split the imported bro logs. Accepted values: \"subfolder\", \"date\"",
 				Value: "",
 			},
 		},
@@ -36,33 +35,35 @@ func init() {
 // doImport runs the importer
 func doImport(c *cli.Context) error {
 	res := database.InitResources(c.String("config"))
-	importDir := c.String("import-dir")
-	databaseName := c.String("database")
+	importDir := c.Args().Get(0)
+	targetDatabase := c.Args().Get(1)
+	splitStrategy := strings.ToLower(c.String("split"))
 	threads := util.Max(c.Int("threads")/2, 1)
 
-	//one flag was set
-	if importDir != "" && databaseName == "" || importDir == "" && databaseName != "" {
-		return cli.NewExitError(
-			"Import failed.\nUse 'rita import' to import the directories "+
-				"specified in the config file or 'rita import -i [import-dir] -d [database-name]' "+
-				"to import bro logs from a given directory.", -1)
+	if importDir == "" || targetDatabase == "" {
+		return cli.NewExitError("Specify a directory to import and a target database", -1)
 	}
 
-	//both flags were set
-	if importDir != "" && databaseName != "" {
-		res.Config.S.Bro.LogPath = importDir
-		res.Config.S.Bro.DBPrefix = ""
-		//Clear out the directory map and set the default database
-		res.Config.S.Bro.DirectoryMap = make(map[string]string)
-		res.Config.S.Bro.DefaultDatabase = databaseName
+	//Remove tailing / when applicable
+	if strings.HasSuffix(importDir, string(os.PathSeparator)) {
+		importDir = importDir[:len(importDir)-len(string(os.PathSeparator))]
 	}
 
-	res.Log.Infof("Importing %s\n", res.Config.S.Bro.LogPath)
-	fmt.Println("[+] Importing " + res.Config.S.Bro.LogPath)
+	res.Config.R.Bro.ImportDirectory = importDir
+	res.Config.R.Bro.TargetDatabase = targetDatabase
+	res.Config.R.Bro.SplitStrategy = config.SplitNone
+	if splitStrategy == "subfolder" {
+		res.Config.R.Bro.SplitStrategy = config.SplitSubfolder
+	} else if splitStrategy == "date" {
+		res.Config.R.Bro.SplitStrategy = config.SplitDate
+	}
+
+	res.Log.Infof("Importing %s\n", res.Config.R.Bro.ImportDirectory)
+	fmt.Println("[+] Importing " + res.Config.R.Bro.ImportDirectory)
 	importer := parser.NewFSImporter(res, threads, threads)
 	datastore := parser.NewMongoDatastore(res.DB.Session, res.MetaDB,
 		res.Config.S.Bro.ImportBuffer, res.Log)
 	importer.Run(datastore)
-	res.Log.Infof("Finished importing %s\n", res.Config.S.Bro.LogPath)
+	res.Log.Infof("Finished importing %s\n", res.Config.R.Bro.ImportDirectory)
 	return nil
 }

--- a/commands/import.go
+++ b/commands/import.go
@@ -3,9 +3,9 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/database"
 	"github.com/ocmdev/rita/parser"
 	"github.com/ocmdev/rita/util"
@@ -14,17 +14,17 @@ import (
 
 func init() {
 	importCommand := cli.Command{
-		Name:      "import",
-		Usage:     "Import bro logs into a database",
-		ArgsUsage: "<directory to import> <target database>",
+		Name:  "import",
+		Usage: "Import bro logs into a target database",
+		UsageText: "rita import [command options] [<import directory> <database root>]\n\n" +
+			"Logs directly in <import directory> will be imported into a database" +
+			" named <database root>. Files in a subfolder of <import directory> will be imported" +
+			" into <database root>-$SUBFOLDER_NAME. <import directory>" +
+			" and <database root> will be loaded from the configuration file unless" +
+			" BOTH arguments are supplied.",
 		Flags: []cli.Flag{
 			threadFlag,
 			configFlag,
-			cli.StringFlag{
-				Name:  "split, s",
-				Usage: "Split the imported bro logs. Accepted values: \"subfolder\", \"date\"",
-				Value: "",
-			},
 		},
 		Action: doImport,
 	}
@@ -37,33 +37,38 @@ func doImport(c *cli.Context) error {
 	res := database.InitResources(c.String("config"))
 	importDir := c.Args().Get(0)
 	targetDatabase := c.Args().Get(1)
-	splitStrategy := strings.ToLower(c.String("split"))
 	threads := util.Max(c.Int("threads")/2, 1)
 
-	if importDir == "" || targetDatabase == "" {
-		return cli.NewExitError("Specify a directory to import and a target database", -1)
+	//check if one argument is set but not the other
+	if importDir != "" && targetDatabase == "" ||
+		importDir == "" && targetDatabase != "" {
+		return cli.NewExitError("Both <directory to import> and <database prefix> are required to override the config file.", -1)
 	}
 
-	//Remove tailing / when applicable
-	if strings.HasSuffix(importDir, string(os.PathSeparator)) {
-		importDir = importDir[:len(importDir)-len(string(os.PathSeparator))]
+	//check if the user overrode the config file
+	if importDir != "" && targetDatabase != "" {
+		//expand relative path
+		//nolint: vetshadow
+		importDir, err := filepath.Abs(importDir)
+		if err != nil {
+			return cli.NewExitError(err.Error(), -1)
+		}
+
+		//Remove tailing / when applicable
+		if strings.HasSuffix(importDir, string(os.PathSeparator)) {
+			importDir = importDir[:len(importDir)-len(string(os.PathSeparator))]
+		}
+
+		res.Config.S.Bro.ImportDirectory = importDir
+		res.Config.S.Bro.DBRoot = targetDatabase
 	}
 
-	res.Config.R.Bro.ImportDirectory = importDir
-	res.Config.R.Bro.TargetDatabase = targetDatabase
-	res.Config.R.Bro.SplitStrategy = config.SplitNone
-	if splitStrategy == "subfolder" {
-		res.Config.R.Bro.SplitStrategy = config.SplitSubfolder
-	} else if splitStrategy == "date" {
-		res.Config.R.Bro.SplitStrategy = config.SplitDate
-	}
-
-	res.Log.Infof("Importing %s\n", res.Config.R.Bro.ImportDirectory)
-	fmt.Println("[+] Importing " + res.Config.R.Bro.ImportDirectory)
+	res.Log.Infof("Importing %s\n", res.Config.S.Bro.ImportDirectory)
+	fmt.Println("[+] Importing " + res.Config.S.Bro.ImportDirectory)
 	importer := parser.NewFSImporter(res, threads, threads)
 	datastore := parser.NewMongoDatastore(res.DB.Session, res.MetaDB,
 		res.Config.S.Bro.ImportBuffer, res.Log)
 	importer.Run(datastore)
-	res.Log.Infof("Finished importing %s\n", res.Config.R.Bro.ImportDirectory)
+	res.Log.Infof("Finished importing %s\n", res.Config.S.Bro.ImportDirectory)
 	return nil
 }

--- a/commands/import.go
+++ b/commands/import.go
@@ -2,9 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/ocmdev/rita/database"
 	"github.com/ocmdev/rita/parser"
@@ -52,11 +50,6 @@ func doImport(c *cli.Context) error {
 		importDir, err := filepath.Abs(importDir)
 		if err != nil {
 			return cli.NewExitError(err.Error(), -1)
-		}
-
-		//Remove tailing / when applicable
-		if strings.HasSuffix(importDir, string(os.PathSeparator)) {
-			importDir = importDir[:len(importDir)-len(string(os.PathSeparator))]
 		}
 
 		res.Config.S.Bro.ImportDirectory = importDir

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -9,10 +9,10 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name: "html-report",
-		Usage: "Create an html report for an analyzed database. " +
+		Name:  "html-report",
+		Usage: "Create an html report for an analyzed database",
+		UsageText: "rita html-report [command-options] [database]\n\n" +
 			"If no database is specified, a report will be created for every database.",
-		ArgsUsage: "[database]",
 		Flags: []cli.Flag{
 			configFlag,
 		},

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -9,19 +9,16 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name:  "html-report",
-		Usage: "Write analysis information to html output",
+		Name: "html-report",
+		Usage: "Create an html report for an analyzed database. " +
+			"If no database is specified, a report will be created for every database.",
+		ArgsUsage: "[database]",
 		Flags: []cli.Flag{
 			configFlag,
-			cli.StringFlag{
-				Name:  "database, d",
-				Usage: "Specify which databases to export, otherwise will export all databases",
-				Value: "",
-			},
 		},
 		Action: func(c *cli.Context) error {
 			res := database.InitResources(c.String("config"))
-			databaseName := c.String("database")
+			databaseName := c.Args().Get(0)
 			var databases []string
 			if databaseName != "" {
 				databases = append(databases, databaseName)

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -13,18 +13,19 @@ import (
 
 func init() {
 	reset := cli.Command{
-		Name:  "reset-analysis",
-		Usage: "Reset analysis of one or more databases",
+		Name:      "reset-analysis",
+		Usage:     "Reset analysis of a database",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
 			res := database.InitResources(c.String("config"))
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
-			return cleanAnalysis(c.String("database"), res)
+			return cleanAnalysis(db, res)
 		},
 	}
 

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -13,11 +13,11 @@ import (
 
 func init() {
 	command := cli.Command{
-		Name:  "show-beacons",
-		Usage: "Print beacon information to standard out",
+		Name:      "show-beacons",
+		Usage:     "Print hosts which show signs of C2 software",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			configFlag,
 		},
 		Action: showBeacons,
@@ -27,18 +27,19 @@ func init() {
 }
 
 func showBeacons(c *cli.Context) error {
-	if c.String("database") == "" {
-		return cli.NewExitError("Specify a database with -d", -1)
+	db := c.Args().Get(0)
+	if db == "" {
+		return cli.NewExitError("Specify a database", -1)
 	}
 	res := database.InitResources(c.String("config"))
-	res.DB.SelectDB(c.String("database"))
+	res.DB.SelectDB(db)
 
 	var data []beaconData.BeaconAnalysisView
 
 	ssn := res.DB.Session.Copy()
 	resultsView := beacon.GetBeaconResultsView(res, ssn, 0)
 	if resultsView == nil {
-		return cli.NewExitError("No results were found for "+c.String("database"), -1)
+		return cli.NewExitError("No results were found for "+db, -1)
 	}
 	resultsView.All(&data)
 	ssn.Close()

--- a/commands/show-bl-hostname.go
+++ b/commands/show-bl-hostname.go
@@ -19,9 +19,9 @@ import (
 func init() {
 
 	blHostnames := cli.Command{
-		Name: "show-bl-hostnames",
+		Name:      "show-bl-hostnames",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,

--- a/commands/show-bl-ip.go
+++ b/commands/show-bl-ip.go
@@ -20,9 +20,9 @@ const endl = "\r\n"
 
 func init() {
 	blSourceIPs := cli.Command{
-		Name: "show-bl-source-ips",
+		Name:      "show-bl-source-ips",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
@@ -33,9 +33,9 @@ func init() {
 	}
 
 	blDestIPs := cli.Command{
-		Name: "show-bl-dest-ips",
+		Name:      "show-bl-dest-ips",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
@@ -49,12 +49,12 @@ func init() {
 }
 
 func parseBLArgs(c *cli.Context) (string, string, bool, bool, error) {
-	db := c.String("database")
+	db := c.Args().Get(0)
 	sort := c.String("sort")
 	connected := c.Bool("connected")
 	human := c.Bool("human-readable")
 	if db == "" {
-		return db, sort, connected, human, cli.NewExitError("Specify a database with -d", -1)
+		return db, sort, connected, human, cli.NewExitError("Specify a database", -1)
 	}
 	if sort != "conn" && sort != "uconn" && sort != "total_bytes" {
 		return db, sort, connected, human, cli.NewExitError("Invalid option passed to sort flag", -1)

--- a/commands/show-bl-url.go
+++ b/commands/show-bl-url.go
@@ -18,9 +18,9 @@ import (
 
 func init() {
 	blURLs := cli.Command{
-		Name: "show-bl-urls",
+		Name:      "show-bl-urls",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
-			databaseFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -13,27 +13,28 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name:  "show-exploded-dns",
-		Usage: "Print dns analysis. Exposes covert dns channels.",
+		Name:      "show-exploded-dns",
+		Usage:     "Print dns analysis. Exposes covert dns channels.",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
 			res := database.InitResources(c.String("config"))
 
 			var explodedResults []dns.ExplodedDNS
-			iter := res.DB.Session.DB(c.String("database")).C(res.Config.T.DNS.ExplodedDNSTable).Find(nil)
+			iter := res.DB.Session.DB(db).C(res.Config.T.DNS.ExplodedDNSTable).Find(nil)
 
 			iter.Sort("-subdomains").All(&explodedResults)
 
 			if len(explodedResults) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -14,7 +14,7 @@ func init() {
 	command := cli.Command{
 
 		Name:      "show-exploded-dns",
-		Usage:     "Print dns analysis. Exposes covert dns channels.",
+		Usage:     "Print dns analysis. Exposes covert dns channels",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -14,29 +14,30 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name:  "show-long-connections",
-		Usage: "Print long connections and relevant information",
+		Name:      "show-long-connections",
+		Usage:     "Print long connections and relevant information",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
 			res := database.InitResources(c.String("config"))
 
 			var longConns []data.Conn
-			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Structure.ConnTable)
+			coll := res.DB.Session.DB(db).C(res.Config.T.Structure.ConnTable)
 
 			sortStr := "-duration"
 
 			coll.Find(nil).Sort(sortStr).All(&longConns)
 
 			if len(longConns) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {

--- a/commands/show-scans.go
+++ b/commands/show-scans.go
@@ -14,31 +14,32 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name:  "show-scans",
-		Usage: "Print scanning information",
+		Name:      "show-scans",
+		Usage:     "Print scanning information",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			configFlag,
 			cli.BoolFlag{
 				Name:  "ports, P",
-				Usage: "show which individual ports were scanned",
+				Usage: "Show which individual ports were scanned",
 			},
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 			showPorts := c.Bool("ports")
 
 			res := database.InitResources(c.String("config"))
 
 			var scans []scanning.Scan
-			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Scanning.ScanTable)
+			coll := res.DB.Session.DB(db).C(res.Config.T.Scanning.ScanTable)
 			coll.Find(nil).All(&scans)
 
 			if len(scans) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {

--- a/commands/show-urls.go
+++ b/commands/show-urls.go
@@ -14,27 +14,28 @@ import (
 func init() {
 	longURLs := cli.Command{
 
-		Name:  "show-long-urls",
-		Usage: "Print the longest urls",
+		Name:      "show-long-urls",
+		Usage:     "Print the longest urls",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
 			res := database.InitResources(c.String("config"))
 
 			var urls []urls.URL
-			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Urls.UrlsTable)
+			coll := res.DB.Session.DB(db).C(res.Config.T.Urls.UrlsTable)
 
 			coll.Find(nil).Sort("-length").All(&urls)
 
 			if len(urls) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {
@@ -55,26 +56,27 @@ func init() {
 
 	vistedURLs := cli.Command{
 
-		Name:  "show-most-visited-urls",
-		Usage: "Print the most visited urls",
+		Name:      "show-most-visited-urls",
+		Usage:     "Print the most visited urls",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := database.InitResources("")
+			res := database.InitResources(c.String("config"))
 
 			var urls []urls.URL
-			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.Urls.UrlsTable)
+			coll := res.DB.Session.DB(db).C(res.Config.T.Urls.UrlsTable)
 
 			coll.Find(nil).Sort("-count").All(&urls)
 
 			if len(urls) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -13,11 +13,11 @@ import (
 func init() {
 	command := cli.Command{
 
-		Name:  "show-user-agents",
-		Usage: "Print user agent information",
+		Name:      "show-user-agents",
+		Usage:     "Print user agent information",
+		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			databaseFlag,
 			cli.BoolFlag{
 				Name:  "least-used, l",
 				Usage: "Sort the user agents from least used to most used.",
@@ -25,14 +25,15 @@ func init() {
 			configFlag,
 		},
 		Action: func(c *cli.Context) error {
-			if c.String("database") == "" {
-				return cli.NewExitError("Specify a database with -d", -1)
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
 			}
 
 			res := database.InitResources(c.String("config"))
 
 			var agents []useragent.UserAgent
-			coll := res.DB.Session.DB(c.String("database")).C(res.Config.T.UserAgent.UserAgentTable)
+			coll := res.DB.Session.DB(db).C(res.Config.T.UserAgent.UserAgentTable)
 
 			var sortStr string
 			if c.Bool("least-used") {
@@ -44,7 +45,7 @@ func init() {
 			coll.Find(nil).Sort(sortStr).All(&agents)
 
 			if len(agents) == 0 {
-				return cli.NewExitError("No results were found for "+c.String("database"), -1)
+				return cli.NewExitError("No results were found for "+db, -1)
 			}
 
 			if c.Bool("human-readable") {

--- a/config/running.go
+++ b/config/running.go
@@ -10,31 +10,10 @@ import (
 	"github.com/ocmdev/mgosec"
 )
 
-//BroSplitStrategy defines how log records should be split
-//into separate databases upon import
-type BroSplitStrategy int
-
-const (
-	//SplitNone forces all log records into the same database
-	SplitNone BroSplitStrategy = 0
-
-	//SplitSubfolder appends the subfolder names to the root db name with dashes.
-	//For example a log at ./subfolder1/conn.log would be imported into
-	//DBName-subfolder1
-	SplitSubfolder BroSplitStrategy = 1
-
-	//SplitDate splits the log records by the date according to the record's timestamp.
-	//NOTE: this option should not be used in "live" installations of RITA,
-	//since Bro may insert log records timestamped for the previous day into
-	//the next day's logset.
-	SplitDate BroSplitStrategy = 2
-)
-
 type (
 	//RunningCfg holds configuration options that are parsed at run time
 	RunningCfg struct {
 		MongoDB MongoDBRunningCfg
-		Bro     BroRunningCfg
 		Version semver.Version
 	}
 
@@ -44,13 +23,6 @@ type (
 		TLS                 struct {
 			TLSConfig *tls.Config
 		}
-	}
-
-	//BroRunningCfg controls the file parser
-	BroRunningCfg struct {
-		ImportDirectory string
-		TargetDatabase  string
-		SplitStrategy   BroSplitStrategy
 	}
 )
 

--- a/config/running.go
+++ b/config/running.go
@@ -10,10 +10,31 @@ import (
 	"github.com/ocmdev/mgosec"
 )
 
+//BroSplitStrategy defines how log records should be split
+//into separate databases upon import
+type BroSplitStrategy int
+
+const (
+	//SplitNone forces all log records into the same database
+	SplitNone BroSplitStrategy = 0
+
+	//SplitSubfolder appends the subfolder names to the root db name with dashes.
+	//For example a log at ./subfolder1/conn.log would be imported into
+	//DBName-subfolder1
+	SplitSubfolder BroSplitStrategy = 1
+
+	//SplitDate splits the log records by the date according to the record's timestamp.
+	//NOTE: this option should not be used in "live" installations of RITA,
+	//since Bro may insert log records timestamped for the previous day into
+	//the next day's logset.
+	SplitDate BroSplitStrategy = 2
+)
+
 type (
 	//RunningCfg holds configuration options that are parsed at run time
 	RunningCfg struct {
 		MongoDB MongoDBRunningCfg
+		Bro     BroRunningCfg
 		Version semver.Version
 	}
 
@@ -23,6 +44,13 @@ type (
 		TLS                 struct {
 			TLSConfig *tls.Config
 		}
+	}
+
+	//BroRunningCfg controls the file parser
+	BroRunningCfg struct {
+		ImportDirectory string
+		TargetDatabase  string
+		SplitStrategy   BroSplitStrategy
 	}
 )
 

--- a/config/static.go
+++ b/config/static.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -81,8 +82,10 @@ type (
 
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
-		MetaDB       string `yaml:"MetaDB"`
-		ImportBuffer int    `yaml:"ImportBuffer"`
+		ImportDirectory string `yaml:"ImportDirectory"`
+		DBRoot          string `yaml:"DBRoot"`
+		MetaDB          string `yaml:"MetaDB"`
+		ImportBuffer    int    `yaml:"ImportBuffer"`
 	}
 )
 
@@ -112,6 +115,12 @@ func loadStaticConfig(cfgPath string) (*StaticCfg, error) {
 
 	// set the socket time out in hours
 	config.MongoDB.SocketTimeout *= time.Hour
+
+	// clean the import path
+	// remove tailing / when applicable
+	if strings.HasSuffix(config.Bro.ImportDirectory, string(os.PathSeparator)) {
+		config.Bro.ImportDirectory = config.Bro.ImportDirectory[:len(config.Bro.ImportDirectory)-len(string(config.Bro.ImportDirectory))]
+	}
 
 	// grab the version constants set by the build process
 	config.Version = Version

--- a/config/static.go
+++ b/config/static.go
@@ -81,13 +81,8 @@ type (
 
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
-		LogPath         string            `yaml:"LogPath"`
-		DBPrefix        string            `yaml:"DBPrefix"`
-		MetaDB          string            `yaml:"MetaDB"`
-		DirectoryMap    map[string]string `yaml:"DirectoryMap"`
-		DefaultDatabase string            `yaml:"DefaultDatabase"`
-		UseDates        bool              `yaml:"UseDates"`
-		ImportBuffer    int               `yaml:"ImportBuffer"`
+		MetaDB       string `yaml:"MetaDB"`
+		ImportBuffer int    `yaml:"ImportBuffer"`
 	}
 )
 

--- a/config/static.go
+++ b/config/static.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"strings"
 	"time"
+	"path/filepath"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -116,11 +116,10 @@ func loadStaticConfig(cfgPath string) (*StaticCfg, error) {
 	// set the socket time out in hours
 	config.MongoDB.SocketTimeout *= time.Hour
 
-	// clean the import path
-	// remove tailing / when applicable
-	if strings.HasSuffix(config.Bro.ImportDirectory, string(os.PathSeparator)) {
-		config.Bro.ImportDirectory = config.Bro.ImportDirectory[:len(config.Bro.ImportDirectory)-len(string(config.Bro.ImportDirectory))]
-	}
+	// clean all filepaths
+	config.Log.RitaLogPath = filepath.Clean(config.Log.RitaLogPath)
+	config.Blacklisted.SafeBrowsing.Database = filepath.Clean(config.Blacklisted.SafeBrowsing.Database)
+	config.Bro.ImportDirectory = filepath.Clean(config.Bro.ImportDirectory)
 
 	// grab the version constants set by the build process
 	config.Version = Version

--- a/database/meta.go
+++ b/database/meta.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
+	"github.com/ocmdev/rita/config"
 	fpt "github.com/ocmdev/rita/parser/fileparsetypes"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/mgo.v2"
@@ -44,7 +45,7 @@ func (m *MetaDBHandle) AddNewDB(name string) error {
 		DBMetaInfo{
 			Name:          name,
 			Analyzed:      false,
-			UsingDates:    m.res.Config.S.Bro.UseDates,
+			UsingDates:    m.res.Config.R.Bro.SplitStrategy == config.SplitDate,
 			ImportVersion: m.res.Config.S.Version,
 		},
 	)

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -36,25 +36,6 @@ LogConfig:
 
 # The section Bro configures the bro ingestor
 Bro:
-    # Path to a top level directory of log files
-    LogPath: /opt/bro/logs/
-
-    # If enabled, all databases in this test will get prefixed with the database prefix
-    # DBPrefix: DBPrefix-
-
-    # Subdirectories of LogPath may be separated into different databases for the
-    # test. Map each directory to the database you wish that directory to wind up
-    # in. This is good for running tests against multiple subnets and network
-    # segments. Put the directory name on the left side of the colon, and the
-    # database you wish the logs from that directory to go in on the right side.
-    # DirectoryMap:
-    #     UniqueDir: SeparateDatabaseName
-    #     UniqueDir2: SeparateDatabaseName2
-
-    # If set, files which don't match the directory map will be placed
-    # in this default database.
-    DefaultDatabase: rita
-
     # There needs to be one metadatabase per test. This database holds information
     # about the test and the files related to the test. If there are several
     # subnets mapped in DirectoryMap each will be handled separately and that

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -44,18 +44,8 @@ Bro:
     # into DBRoot-$SUBFOLDER_NAME.
     DBRoot: "RITA"
 
-    # There needs to be one metadatabase per test. This database holds information
-    # about the test and the files related to the test. If there are several
-    # subnets mapped in DirectoryMap each will be handled separately and that
-    # separation is handled by the metadatabase.
+    # This database holds information about the procesed files and databases.
     MetaDB: MetaDatabase
-
-    # If use dates is true the logs will be split into databases by date using the
-    # current system's timezone. This is best for if you have multiple days worth
-    # of log files in the logpath and wish to treat each day as a separate test.
-    # 24 hours worth of data is the ideal for analysis, and using dates will ensure
-    # that tests are broken into 24 hour periods on midnight in the current timezone.
-    UseDates: true
 
     # The number of records shipped off to MongoDB at a time. Increasing
     # the size of the buffer will improve import timings but will leave more

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -36,6 +36,14 @@ LogConfig:
 
 # The section Bro configures the bro ingestor
 Bro:
+    # Path to a top level directory of log files
+    ImportDirectory: /opt/bro/logs/
+
+    # Files directly in the ImportDirectory will be imported into a database
+    # given by DBRoot. Files in a subfolder of ImportDirectory will be imported
+    # into DBRoot-$SUBFOLDER_NAME.
+    DBRoot: "RITA"
+
     # There needs to be one metadatabase per test. This database holds information
     # about the test and the files related to the test. If there are several
     # subnets mapped in DirectoryMap each will be handled separately and that

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,7 @@ __setPkgMgr() {
 	fi
 	if [ $_PKG_MGR -eq 3 ]; then
 		echo "Unsupported package manager"
-		_err
+		__err
 	fi
 }
 
@@ -142,7 +142,7 @@ __setOS() {
 	_OS="$(lsb_release -is)"
 	if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" ]; then
 		echo "Unsupported operating system"
-		_err
+		__err
 	fi
 }
 

--- a/parser/fileparsetypes/fileparsetypes.go
+++ b/parser/fileparsetypes/fileparsetypes.go
@@ -32,7 +32,6 @@ type IndexedFile struct {
 	Hash             string        `bson:"hash"`
 	TargetCollection string        `bson:"collection"`
 	TargetDatabase   string        `bson:"database"`
-	Dates            []string      `bson:"dates"`
 	ParseTime        time.Time     `bson:"time_complete"`
 	header           *BroHeader
 	broDataFactory   func() pt.BroData

--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/ocmdev/rita/config"
 	"github.com/ocmdev/rita/database"
 	fpt "github.com/ocmdev/rita/parser/fileparsetypes"
-	"github.com/ocmdev/rita/parser/parsetypes"
 	"github.com/ocmdev/rita/util"
 	log "github.com/sirupsen/logrus"
 )
@@ -49,7 +47,7 @@ func (fs *FSImporter) Run(datastore Datastore) {
 
 	fmt.Println("\t[-] Finding files to parse")
 	//find all of the bro log paths
-	files := readDir(fs.res.Config.R.Bro.ImportDirectory, fs.res.Log)
+	files := readDir(fs.res.Config.S.Bro.ImportDirectory, fs.res.Log)
 
 	//hash the files and get their stats
 	indexedFiles := indexFiles(files, fs.indexingThreads, fs.res.Config, fs.res.Log)
@@ -64,8 +62,7 @@ func (fs *FSImporter) Run(datastore Datastore) {
 
 	indexedFiles = removeOldFilesFromIndex(indexedFiles, fs.res.MetaDB, fs.res.Log)
 
-	parseFiles(indexedFiles, fs.parseThreads,
-		fs.res.Config.R.Bro.SplitStrategy, datastore, fs.res.Log)
+	parseFiles(indexedFiles, fs.parseThreads, datastore, fs.res.Log)
 
 	datastore.Flush()
 	updateFilesIndex(indexedFiles, fs.res.MetaDB, fs.res.Log)
@@ -154,9 +151,7 @@ func indexFiles(files []string, indexingThreads int,
 //threads to use to parse the files, whether or not to sort data by date,
 // a MogoDB datastore object to store the bro data in, and a logger to report
 //errors and parses the bro files line by line into the database.
-//NOTE: side effect: this sets the dates field on the indexedFiles
-func parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads int,
-	splitStrategy config.BroSplitStrategy, datastore Datastore, logger *log.Logger) {
+func parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads int, datastore Datastore, logger *log.Logger) {
 	//set up parallel parsing
 	n := len(indexedFiles)
 	parsingWG := new(sync.WaitGroup)
@@ -199,25 +194,9 @@ func parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads int,
 					)
 
 					if data != nil {
-						//set the dates this file is represeting
-						date := getDateForLogEntry(data, indexedFiles[j].GetFieldMap())
-						dateFound := false
-						for _, parsedDate := range indexedFiles[j].Dates {
-							if parsedDate == date {
-								dateFound = true
-								break
-							}
-						}
-						if !dateFound {
-							indexedFiles[j].Dates = append(indexedFiles[j].Dates, date)
-						}
-
 						//figure out what database this line is heading for
 						targetCollection := indexedFiles[j].TargetCollection
 						targetDB := indexedFiles[j].TargetDatabase
-						if splitStrategy == config.SplitDate {
-							targetDB += "-" + date
-						}
 
 						datastore.Store(&ImportedData{
 							BroData:          data,
@@ -280,10 +259,4 @@ func updateFilesIndex(indexedFiles []*fpt.IndexedFile, metaDatabase *database.Me
 	if err != nil {
 		logger.Error("Could not update the list of parsed files")
 	}
-}
-
-func getDateForLogEntry(broData parsetypes.BroData, fieldMap fpt.BroHeaderIndexMap) string {
-	data := reflect.ValueOf(broData).Elem()
-	ts := time.Unix(data.Field(fieldMap["ts"]).Int(), 0)
-	return fmt.Sprintf("%d-%02d-%02d", ts.Year(), ts.Month(), ts.Day())
 }


### PR DESCRIPTION
1.) Clean up the cli so you don't have to specify -d for commands which take a database as an argument
2.) Remove the Bro DirectoryMap (all import mapping is done on the cli)
3.) Change the -i and -d to positional arguments in import
4.) Add a --split option on import for splitting by subfolder and splitting by date

Splitting by subfolder appends the subfolder a bro log is found in to the root db name. This can be used with Bro's default file structure to import to DBNameBase-YYYY-MM-DD. Splitting by date tries to infer the dates when each connection is logged and appends that date to the resultant db. (i.e. the current UseDates option)